### PR TITLE
Add InlineOperation and the rerun(while:for:) modifier

### DIFF
--- a/Sources/OperationCore/InlineOperation.swift
+++ b/Sources/OperationCore/InlineOperation.swift
@@ -1,0 +1,69 @@
+// MARK: - InlineOperation
+
+/// An ``OperationRequest`` defined by a closure.
+///
+/// Operations are usually declared with the `@OperationRequest` macro, or by conforming a type to
+/// ``OperationRequest`` directly. Neither is available to work that closes over local state, such
+/// as a process handle or a file descriptor that only exists inside the function performing the
+/// work. An inline operation describes that work as a value, so that it composes with modifiers
+/// like any other operation.
+///
+/// ```swift
+/// let process = try launchServer()
+/// let didStart = try await #run(
+///   InlineOperation("server readiness") { _ in await isListening(on: port) }
+///     .rerun(while: { !$0 }, for: .seconds(30))
+/// )
+/// ```
+///
+/// An inline operation is deliberately not a ``StatefulOperationRequest``, so it cannot be held by
+/// an ``OperationStore``. A store identifies its operation by ``OperationPath``, and two closures
+/// have no useful notion of equality for a path to be derived from. Inline operations are for the
+/// ``OperationRunner`` and `#run` path, where an operation is run once and its result returned.
+public struct InlineOperation<Value, Failure: Error>: OperationRequest, Sendable {
+  public typealias Run =
+    @Sendable (
+      OperationContext,
+      OperationContinuation<Value, Failure>
+    ) async throws(Failure) -> Value
+
+  private let debugName: String?
+  private let _run: Run
+
+  /// Creates an inline operation.
+  ///
+  /// - Parameters:
+  ///   - debugName: A name for this operation, reported by ``OperationRequest/_debugTypeName``.
+  ///     Modifiers that log or record operations use that name, and the type name of a closure
+  ///     backed operation says nothing about what it does.
+  ///   - run: The work this operation performs. See <doc:MultistageOperations> for what the
+  ///     ``OperationContinuation`` handed to it is for.
+  public init(_ debugName: String? = nil, run: @escaping Run) {
+    self.debugName = debugName
+    self._run = run
+  }
+
+  /// Creates an inline operation that returns a single result.
+  ///
+  /// - Parameters:
+  ///   - debugName: A name for this operation, reported by ``OperationRequest/_debugTypeName``.
+  ///   - run: The work this operation performs.
+  public init(
+    _ debugName: String? = nil,
+    run: @escaping @Sendable (OperationContext) async throws(Failure) -> Value
+  ) {
+    self.init(debugName) { context, _ throws(Failure) in try await run(context) }
+  }
+
+  public var _debugTypeName: String {
+    self.debugName ?? typeName(Self.self)
+  }
+
+  public func run(
+    isolation: isolated (any Actor)?,
+    in context: OperationContext,
+    with continuation: OperationContinuation<Value, Failure>
+  ) async throws(Failure) -> Value {
+    try await self._run(context, continuation)
+  }
+}

--- a/Sources/OperationCore/Modifiers/RerunOperation.swift
+++ b/Sources/OperationCore/Modifiers/RerunOperation.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+// MARK: - RerunModifier
+
+extension OperationRequest {
+  /// Reruns this operation while its value is unsatisfactory, for up to a specified duration.
+  ///
+  /// ``OperationRequest/retry(limit:)`` reruns an operation that *failed*, a fixed number of
+  /// times. This modifier reruns an operation that *succeeded with a value worth asking about
+  /// again*, until a deadline. Waiting for something to become true is the common case: a port
+  /// that will start answering, a lock that will become free, a process that will exit. None of
+  /// those are errors while they are still pending, and none of them are bounded by an attempt
+  /// count, because with backoff a count of attempts says nothing about how long the wait lasts.
+  ///
+  /// ```swift
+  /// let isReady = try await #run(
+  ///   $serverIsListening(port: port)
+  ///     .rerun(while: { !$0 }, for: .seconds(30))
+  ///     .backoff(.exponential(.milliseconds(50)))
+  /// )
+  /// ```
+  ///
+  /// The operation always runs at least once, however short the duration. If the duration elapses
+  /// while the value is still unsatisfactory, the last value is returned rather than an error
+  /// being thrown, so that the caller can report the timeout in its own terms. A run that throws
+  /// is not rerun, and the error is rethrown immediately: rerunning is only worth doing while the
+  /// awaited state is still possible.
+  ///
+  /// The delay between runs comes from ``OperationContext/operationBackoffFunction`` and
+  /// ``OperationContext/operationDelayer``, as it does for retries. The final delay is clamped to
+  /// whatever remains of the duration, so the last run happens at the deadline rather than past
+  /// it.
+  ///
+  /// - Parameters:
+  ///   - shouldRerun: Whether a value is worth running the operation again for.
+  ///   - duration: How long to keep rerunning the operation for.
+  /// - Returns: A ``ModifiedOperation``.
+  public func rerun(
+    while shouldRerun: @escaping @Sendable (Value) -> Bool,
+    for duration: OperationDuration
+  ) -> ModifiedOperation<Self, _RerunModifier<Self>> {
+    self.modifier(_RerunModifier(shouldRerun: shouldRerun, duration: duration))
+  }
+}
+
+public struct _RerunModifier<Operation: OperationRequest>: OperationModifier, Sendable {
+  let shouldRerun: @Sendable (Operation.Value) -> Bool
+  let duration: OperationDuration
+
+  public func run(
+    isolation: isolated (any Actor)?,
+    in context: OperationContext,
+    using operation: Operation,
+    with continuation: OperationContinuation<Operation.Value, Operation.Failure>
+  ) async throws(Operation.Failure) -> Operation.Value {
+    let clock = context.operationClock
+    let start = clock.now()
+    var rerunCount = 0
+    while true {
+      let value = try await operation.run(isolation: isolation, in: context, with: continuation)
+      guard self.shouldRerun(value) else { return value }
+      let elapsed = OperationDuration.seconds(clock.now().timeIntervalSince(start))
+      let remaining = self.duration - elapsed
+      guard remaining > .zero else { return value }
+      rerunCount += 1
+      let backoff = context.operationBackoffFunction(rerunCount)
+      // A cancelled delay is swallowed rather than thrown, because the operation's Failure type
+      // has no room for a cancellation error. Returning on cancellation is what keeps that from
+      // becoming a loop that spins until the deadline.
+      try? await context.operationDelayer.delay(for: min(backoff, remaining))
+      guard !Task.isCancelled else { return value }
+    }
+  }
+}

--- a/Tests/OperationTests/InlineOperationTests.swift
+++ b/Tests/OperationTests/InlineOperationTests.swift
@@ -1,0 +1,60 @@
+import CustomDump
+import Operation
+import Testing
+
+@Suite("InlineOperation tests")
+struct InlineOperationTests {
+  @Test("Returns The Value From The Closure")
+  func returnsTheValueFromTheClosure() async {
+    let value = await #run(InlineOperation { _ in 42 })
+    expectNoDifference(value, 42)
+  }
+
+  @Test("Rethrows The Error From The Closure")
+  func rethrowsTheErrorFromTheClosure() async {
+    let operation = InlineOperation<Int, any Error> { _ in throw SomeError() }
+    await #expect(throws: SomeError.self) { try await #run(operation) }
+  }
+
+  @Test("Reads Values From The Context It Is Run In")
+  func readsValuesFromTheContextItIsRunIn() async {
+    var context = OperationContext()
+    context.operationMaxRetries = 7
+    let value = await #run(InlineOperation { $0.operationMaxRetries }, context: context)
+    expectNoDifference(value, 7)
+  }
+
+  @Test("Yields Values Through The Continuation")
+  func yieldsValuesThroughTheContinuation() async throws {
+    let yielded = RecursiveLock([Int]())
+    let operation = InlineOperation<Int, any Error> { _, continuation in
+      continuation.yield(1)
+      continuation.yield(2)
+      return 3
+    }
+    let value = try await #run(
+      operation,
+      context: OperationContext(),
+      continuation: OperationContinuation { result, _ in
+        guard case .success(let next) = result else { return }
+        yielded.withLock { $0.append(next) }
+      }
+    )
+    expectNoDifference(value, 3)
+    expectNoDifference(yielded.withLock { $0 }, [1, 2])
+  }
+
+  @Test("Uses The Provided Debug Name")
+  func usesTheProvidedDebugName() {
+    let operation = InlineOperation("server readiness") { _ in true }
+    expectNoDifference(operation._debugTypeName, "server readiness")
+  }
+
+  @Test("Falls Back To The Type Name Without A Debug Name")
+  func fallsBackToTheTypeNameWithoutADebugName() {
+    let operation = InlineOperation { _ in true }
+    expectNoDifference(operation._debugTypeName.hasPrefix("InlineOperation"), true)
+  }
+}
+
+private struct SomeError: Equatable, Error {}

--- a/Tests/OperationTests/ModifiersTests/RerunOperationTests.swift
+++ b/Tests/OperationTests/ModifiersTests/RerunOperationTests.swift
@@ -1,0 +1,189 @@
+import CustomDump
+import Foundation
+import Operation
+import Testing
+
+@Suite("RerunOperation tests")
+struct RerunOperationTests {
+  @Test("Runs Once When The First Value Is Satisfactory")
+  func runsOnceWhenTheFirstValueIsSatisfactory() async {
+    let counter = RunCounter()
+    let delayer = AdvancingDelayer()
+    let value = await #run(
+      counter.operation { _ in true }
+        .rerun(while: { !$0 }, for: .seconds(30))
+        .delayer(delayer)
+        .clock(delayer.clock)
+    )
+    expectNoDifference(value, true)
+    expectNoDifference(counter.count, 1)
+    expectNoDifference(delayer.delays, [])
+  }
+
+  @Test("Reruns Until The Value Is Satisfactory")
+  func rerunsUntilTheValueIsSatisfactory() async {
+    let counter = RunCounter()
+    let delayer = AdvancingDelayer()
+    let value = await #run(
+      counter.operation { $0 >= 3 }
+        .rerun(while: { !$0 }, for: .seconds(30))
+        .backoff(.constant(.milliseconds(100)))
+        .delayer(delayer)
+        .clock(delayer.clock)
+    )
+    expectNoDifference(value, true)
+    expectNoDifference(counter.count, 3)
+    expectNoDifference(delayer.delays, [.milliseconds(100), .milliseconds(100)])
+  }
+
+  @Test("Returns The Last Value When The Duration Elapses")
+  func returnsTheLastValueWhenTheDurationElapses() async {
+    let counter = RunCounter()
+    let delayer = AdvancingDelayer()
+    let value = await #run(
+      counter.operation { _ in false }
+        .rerun(while: { !$0 }, for: .seconds(1))
+        .backoff(.constant(.milliseconds(400)))
+        .delayer(delayer)
+        .clock(delayer.clock)
+    )
+    expectNoDifference(value, false)
+    expectNoDifference(counter.count, 4)
+  }
+
+  @Test("Clamps The Final Delay To What Remains Of The Duration")
+  func clampsTheFinalDelayToWhatRemainsOfTheDuration() async {
+    let delayer = AdvancingDelayer()
+    _ = await #run(
+      RunCounter().operation { _ in false }
+        .rerun(while: { !$0 }, for: .seconds(1))
+        .backoff(.constant(.milliseconds(400)))
+        .delayer(delayer)
+        .clock(delayer.clock)
+    )
+    // The final delay is the remainder of the second, not another full 400ms. It is not asserted
+    // exactly: `OperationClock` measures in `Date`, whose Double mantissa only resolves about
+    // 100ns at real world timestamps, so the remainder carries a little noise.
+    expectNoDifference(delayer.delays.count, 3)
+    expectNoDifference(Array(delayer.delays.prefix(2)), [.milliseconds(400), .milliseconds(400)])
+    expectNoDifference(delayer.delays[2] < .milliseconds(400), true)
+    expectNoDifference(delayer.delays[2] > .milliseconds(199), true)
+  }
+
+  @Test("Delays By An Increasing Backoff For Each Rerun")
+  func delaysByAnIncreasingBackoffForEachRerun() async {
+    let counter = RunCounter()
+    let delayer = AdvancingDelayer()
+    _ = await #run(
+      counter.operation { $0 >= 4 }
+        .rerun(while: { !$0 }, for: .seconds(30))
+        .backoff(.exponential(.milliseconds(100)))
+        .delayer(delayer)
+        .clock(delayer.clock)
+    )
+    expectNoDifference(
+      delayer.delays,
+      [.milliseconds(100), .milliseconds(200), .milliseconds(400)]
+    )
+  }
+
+  @Test("Runs Once When The Duration Is Zero")
+  func runsOnceWhenTheDurationIsZero() async {
+    let counter = RunCounter()
+    let delayer = AdvancingDelayer()
+    let value = await #run(
+      counter.operation { _ in false }
+        .rerun(while: { !$0 }, for: .zero)
+        .delayer(delayer)
+        .clock(delayer.clock)
+    )
+    expectNoDifference(value, false)
+    expectNoDifference(counter.count, 1)
+    expectNoDifference(delayer.delays, [])
+  }
+
+  @Test("Does Not Rerun An Operation That Throws")
+  func doesNotRerunAnOperationThatThrows() async {
+    let counter = RunCounter()
+    let delayer = AdvancingDelayer()
+    let operation = InlineOperation<Bool, any Error> { _ in
+      counter.increment()
+      throw SomeError()
+    }
+    await #expect(throws: SomeError.self) {
+      try await #run(
+        operation.rerun(while: { !$0 }, for: .seconds(30))
+          .delayer(delayer)
+          .clock(delayer.clock)
+      )
+    }
+    expectNoDifference(counter.count, 1)
+    expectNoDifference(delayer.delays, [])
+  }
+
+  @Test("Stops Rerunning When The Task Is Cancelled")
+  func stopsRerunningWhenTheTaskIsCancelled() async {
+    let counter = RunCounter()
+    let task = Task {
+      await #run(
+        counter.operation { _ in false }
+          .rerun(while: { !$0 }, for: .seconds(30))
+          .backoff(.noBackoff)
+          .delayer(.noDelay)
+      )
+    }
+    task.cancel()
+    let value = await task.value
+    expectNoDifference(value, false)
+    expectNoDifference(counter.count < 3, true)
+  }
+}
+
+// MARK: - Helpers
+
+private struct SomeError: Equatable, Error {}
+
+/// Counts runs, and reports whether the run it just performed is satisfactory.
+private final class RunCounter: Sendable {
+  private let _count = RecursiveLock(0)
+
+  var count: Int {
+    self._count.withLock { $0 }
+  }
+
+  func increment() {
+    self._count.withLock { $0 += 1 }
+  }
+
+  func operation(
+    _ isSatisfactory: @escaping @Sendable (Int) -> Bool
+  ) -> InlineOperation<Bool, Never> {
+    InlineOperation("counted") { _ in
+      isSatisfactory(
+        self._count.withLock { count in
+          count += 1
+          return count
+        }
+      )
+    }
+  }
+}
+
+/// A delayer that advances a clock by the delay rather than sleeping, so that a deadline can be
+/// reached deterministically.
+private final class AdvancingDelayer: OperationDelayer, Sendable {
+  let clock = TestOperationClock(date: Date(timeIntervalSince1970: 0))
+  private let _delays = RecursiveLock([OperationDuration]())
+
+  var delays: [OperationDuration] {
+    self._delays.withLock { $0 }
+  }
+
+  func delay(for duration: OperationDuration) async throws {
+    self._delays.withLock { $0.append(duration) }
+    let (seconds, attoseconds) = duration.components
+    self.clock.date = self.clock.date.addingTimeInterval(
+      TimeInterval(seconds) + TimeInterval(attoseconds) / 1e18
+    )
+  }
+}


### PR DESCRIPTION
Two gaps that surfaced while using the library for CLI process supervision rather than for fetching. Both are on the stateless `#run` path.

## `rerun(while:for:)`

`retry(limit:)` reruns an operation that *failed*, a fixed number of times. Waiting for something to become true is a different shape: a port that will start answering, a lock that will come free, a process that will exit. None of those are errors while they are still pending, so there is nothing to retry on — and none of them are naturally bounded by an attempt count, because under backoff a count says nothing about how long the wait actually lasts. Every wait in the consumer that prompted this is expressed as a timeout; none as a count.

```swift
let isReady = try await #run(
  $serverIsListening(port: port)
    .rerun(while: { !$0 }, for: .seconds(30))
    .backoff(.exponential(.milliseconds(50)))
)
```

- The operation always runs at least once, however short the duration.
- On timeout it returns the last value rather than throwing, so each caller reports its own diagnosis. "The app never listened on its port" and "the MUX never answered its admin port" are the same wait but not the same error.
- A run that throws is not rerun; the error propagates immediately. Rerunning is only worth doing while the awaited state is still reachable.
- The final delay is clamped to what remains of the duration, so the last run lands at the deadline rather than past it.

### Cancellation

The delay is `try?`-ed, matching `_RetryModifier`, because the operation's `Failure` type has no room for a cancellation error. That alone would turn a cancelled rerun into a loop that spins until the deadline, so the modifier returns when the task is cancelled. Removing that check makes `stopsRerunningWhenTheTaskIsCancelled` take 30 seconds instead of failing fast — I verified that.

## `InlineOperation`

None of the above is reachable from work that closes over local state. `@OperationRequest` applies to functions, and `AnyOperation` only erases an operation that already exists, so a process handle or file descriptor living inside the calling function cannot be described as an operation at all — and therefore cannot use any modifier. Every polling site I wanted to convert was of exactly that shape.

```swift
let process = try launchServer()
let didStart = try await #run(
  InlineOperation("server readiness") { _ in await isListening(on: port) }
    .rerun(while: { !$0 }, for: .seconds(30))
)
```

It is deliberately **not** a `StatefulOperationRequest`. A store identifies its operation by `OperationPath`, and two closures have no equality for a path to be derived from. The optional debug name exists because `typeName(InlineOperation<Bool, Never>.self)` tells you nothing in a log, and it is closure-backed operations that most need naming.

A pleasant consequence of typed throws: a non-throwing closure infers `Failure == Never`, so `#run` needs no `try`.

## Two design notes

**No `Duration` overload for `rerun(while:for:)`.** I wrote one first, and it makes `.seconds(30)` ambiguous at every call site between `Duration.seconds` and `OperationDuration.seconds`. `OperationBackoffFunction` already takes only `OperationDuration`, so this follows that.

**`OperationClock` is `Date`-based, which bounds deadline precision.** `Date` stores an offset from 2001, so at real timestamps (~1e9 s) the Double mantissa only resolves about 100ns, and the clamped remainder comes out as e.g. `200000047683715840` attoseconds rather than `2e17`. Irrelevant for a 30-second readiness wait, and I used `operationClock` because `_DurationLoggingModifier` already measures elapsed time that way and it keeps the modifier testable. Flagging it in case you would rather this measured on a monotonic clock — that seemed like your call rather than something to introduce unilaterally.

## Verification

498 tests in 40 suites pass; the 25 known issues are unchanged. Beyond the cancellation mutation above, removing the delay clamp fails `clampsTheFinalDelayToWhatRemainsOfTheDuration`. New files are lint-clean.

I also checked this against the real consumer rather than only the tests: pointing that package at this branch and converting one readiness poll to `InlineOperation` + `.rerun` builds and passes its E2E suite, which exercises the path against an actual subprocess.

## Not included

`retry(for:)` — the deadline-bounded, error-driven counterpart — belongs in `RetryOperation.swift`, which I understand is being worked on separately, so I left it alone rather than creating a conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)