### PR TITLE
Add OperationRuntime for sharing context and modifiers across operations

### DIFF
--- a/Sources/OperationCore/OperationRuntime.swift
+++ b/Sources/OperationCore/OperationRuntime.swift
@@ -1,0 +1,123 @@
+// MARK: - OperationDecorator
+
+/// A protocol that applies modifiers to every operation run by an ``OperationRuntime``.
+///
+/// Conform to this protocol when a group of operations should share behavior, rather than
+/// restating that behavior at every call site.
+///
+/// ```swift
+/// struct SupervisionDecorator: OperationDecorator {
+///   func decorate<Operation: OperationRequest>(
+///     _ operation: Operation
+///   ) -> any OperationRequest<Operation.Value, Operation.Failure> {
+///     operation.retry(limit: 3)
+///       .backoff(.exponential(.milliseconds(50)).jittered())
+///   }
+/// }
+/// ```
+///
+/// This is a protocol rather than a closure because a closure cannot be generic over the operation
+/// it decorates, and the decoration has to preserve that operation's `Value` and `Failure`.
+/// ``OperationClient/StoreCreator`` takes the same shape for the same reason.
+public protocol OperationDecorator: Sendable {
+  /// Applies modifiers to an operation.
+  ///
+  /// - Parameter operation: The operation being run.
+  /// - Returns: `operation` with this decorator's modifiers applied.
+  func decorate<Operation: OperationRequest>(
+    _ operation: Operation
+  ) -> any OperationRequest<Operation.Value, Operation.Failure>
+}
+
+// MARK: - UndecoratedOperations
+
+/// An ``OperationDecorator`` that applies no modifiers.
+public struct UndecoratedOperations: OperationDecorator {
+  public init() {}
+
+  public func decorate<Operation: OperationRequest>(
+    _ operation: Operation
+  ) -> any OperationRequest<Operation.Value, Operation.Failure> {
+    operation
+  }
+}
+
+extension OperationDecorator where Self == UndecoratedOperations {
+  /// An ``OperationDecorator`` that applies no modifiers.
+  public static var undecorated: Self {
+    UndecoratedOperations()
+  }
+}
+
+// MARK: - OperationRuntime
+
+/// A runtime that runs any ``OperationRequest`` with a shared ``OperationContext`` and a shared
+/// set of modifiers.
+///
+/// ``OperationRunner`` runs a single operation, and `#run` builds one with a fresh
+/// ``OperationContext`` each time it is invoked. Neither is somewhere shared policy can live, so a
+/// program that runs many operations restates that policy at every call site, and nothing that
+/// runs in one operation is visible to the next. An `OperationRuntime` is to `OperationRunner`
+/// what ``OperationClient`` is to ``OperationStore``: the place defaults are declared once.
+///
+/// ```swift
+/// let runtime = OperationRuntime(decorator: SupervisionDecorator())
+///
+/// let mux = try await runtime.run($launchMux(project))
+/// let endpoint = try await runtime.run($bindEndpoint(mux.port))
+/// ```
+///
+/// Much of what looks like duplicated modifiers is duplicated *context*. ``backoff(_:)``,
+/// ``delayer(_:)`` and ``clock(_:)`` only write context values, so setting them on the runtime's
+/// ``context`` covers them without a decorator at all. A decorator is for modifiers that wrap a
+/// run, such as ``OperationRequest/retry(limit:)``.
+///
+/// The runtime's modifiers are applied *around* the operation's own. Where a modifier defines what
+/// happens when it is applied twice, that definition decides which one wins: an operation that
+/// already carries ``OperationRequest/retry(limit:)`` keeps its own limit rather than the
+/// runtime's, in the same way that an operation overrides the retry behavior an `OperationClient`
+/// applies by default.
+public struct OperationRuntime: Sendable {
+  /// The ``OperationContext`` handed to every operation this runtime runs.
+  public var context: OperationContext
+
+  /// The ``OperationDecorator`` applied to every operation this runtime runs.
+  public let decorator: any OperationDecorator
+
+  /// Creates a runtime.
+  ///
+  /// - Parameters:
+  ///   - context: The ``OperationContext`` to hand to every operation this runtime runs.
+  ///   - decorator: The ``OperationDecorator`` to apply to every operation this runtime runs.
+  public init(
+    context: OperationContext = OperationContext(),
+    decorator: any OperationDecorator = .undecorated
+  ) {
+    self.context = context
+    self.decorator = decorator
+  }
+
+  /// Runs an operation.
+  ///
+  /// The operation is decorated, and then ``OperationRequest/setup(context:)-8y79v`` is invoked on
+  /// the result with a copy of this runtime's ``context``. Setup runs per call rather than once,
+  /// because a runtime runs a different operation each time.
+  ///
+  /// - Parameters:
+  ///   - operation: The ``OperationRequest`` to run.
+  ///   - isolation: The current actor-isolation of this operation run.
+  ///   - continuation: An ``OperationContinuation`` that allows you to yield data while the
+  ///   operation is still running. See <doc:MultistageOperations> for more.
+  /// - Returns: The value returned from the operation.
+  public func run<Operation: OperationRequest>(
+    _ operation: Operation,
+    isolation: isolated (any Actor)? = #isolation,
+    with continuation: OperationContinuation<Operation.Value, Operation.Failure> =
+      OperationContinuation { _, _ in }
+  ) async throws(Operation.Failure) -> Operation.Value {
+    let decorated = self.decorator.decorate(operation)
+    var context = self.context
+    decorated.setup(context: &context)
+    return try await decorated.run(isolation: isolation, in: context, with: continuation)
+  }
+}

--- a/Tests/OperationTests/OperationRuntimeTests.swift
+++ b/Tests/OperationTests/OperationRuntimeTests.swift
@@ -1,0 +1,114 @@
+import CustomDump
+import Operation
+import Testing
+
+@Suite("OperationRuntime tests")
+struct OperationRuntimeTests {
+  @Test("Runs An Operation Without A Decorator")
+  func runsAnOperationWithoutADecorator() async {
+    let runtime = OperationRuntime()
+    let value = await runtime.run(InlineOperation { _ in 42 })
+    expectNoDifference(value, 42)
+  }
+
+  @Test("Hands Its Context To Every Operation It Runs")
+  func handsItsContextToEveryOperationItRuns() async {
+    var context = OperationContext()
+    context.operationMaxRetries = 7
+    let runtime = OperationRuntime(context: context)
+    let first = await runtime.run(InlineOperation { $0.operationMaxRetries })
+    let second = await runtime.run(InlineOperation { $0.operationMaxRetries })
+    expectNoDifference([first, second], [7, 7])
+  }
+
+  @Test("Applies Its Decorator To Every Operation It Runs")
+  func appliesItsDecoratorToEveryOperationItRuns() async {
+    let counter = RunCounter()
+    let runtime = OperationRuntime(decorator: RetryingDecorator(limit: 3))
+    await #expect(throws: SomeError.self) {
+      try await runtime.run(counter.alwaysFailingOperation())
+    }
+    expectNoDifference(counter.count, 4)
+  }
+
+  @Test("Decorates Operations Of Differing Value And Failure Types")
+  func decoratesOperationsOfDifferingValueAndFailureTypes() async {
+    let runtime = OperationRuntime(decorator: RetryingDecorator(limit: 1))
+    let number = await runtime.run(InlineOperation { _ in 1 })
+    let text = await runtime.run(InlineOperation { _ in "blob" })
+    expectNoDifference(number, 1)
+    expectNoDifference(text, "blob")
+  }
+
+  @Test("An Operation's Own Retry Limit Takes Precedence Over The Runtime's")
+  func anOperationsOwnRetryLimitTakesPrecedenceOverTheRuntimes() async {
+    let counter = RunCounter()
+    let runtime = OperationRuntime(decorator: RetryingDecorator(limit: 10))
+    await #expect(throws: SomeError.self) {
+      try await runtime.run(
+        counter.alwaysFailingOperation()
+          .retry(limit: 1)
+          .backoff(.noBackoff)
+          .delayer(.noDelay)
+      )
+    }
+    expectNoDifference(counter.count, 2)
+  }
+
+  @Test("Yields Values Through The Continuation")
+  func yieldsValuesThroughTheContinuation() async {
+    let yielded = RecursiveLock([Int]())
+    let runtime = OperationRuntime()
+    let operation = InlineOperation<Int, Never> { _, continuation in
+      continuation.yield(1)
+      return 2
+    }
+    let value = await runtime.run(
+      operation,
+      with: OperationContinuation { result, _ in
+        guard case .success(let next) = result else { return }
+        yielded.withLock { $0.append(next) }
+      }
+    )
+    expectNoDifference(value, 2)
+    expectNoDifference(yielded.withLock { $0 }, [1])
+  }
+
+  @Test("Invokes Setup On The Decorated Operation")
+  func invokesSetupOnTheDecoratedOperation() async {
+    let runtime = OperationRuntime(decorator: RetryingDecorator(limit: 4))
+    // `retry(limit:)` writes the limit into the context during setup, so an operation that reads
+    // it back can only see 4 if the decorator's setup ran.
+    let limit = await runtime.run(InlineOperation { $0.operationMaxRetries })
+    expectNoDifference(limit, 4)
+  }
+}
+
+// MARK: - Helpers
+
+private struct SomeError: Equatable, Error {}
+
+private struct RetryingDecorator: OperationDecorator {
+  let limit: Int
+
+  func decorate<Operation: OperationRequest>(
+    _ operation: Operation
+  ) -> any OperationRequest<Operation.Value, Operation.Failure> {
+    operation.retry(limit: self.limit).backoff(.noBackoff).delayer(.noDelay)
+  }
+}
+
+private final class RunCounter: Sendable {
+  private let _count = RecursiveLock(0)
+
+  var count: Int {
+    self._count.withLock { $0 }
+  }
+
+  func alwaysFailingOperation() -> InlineOperation<Int, any Error> {
+    InlineOperation("always failing") { _ in
+      self._count.withLock { $0 += 1 }
+      throw SomeError()
+    }
+  }
+}


### PR DESCRIPTION
> **Stacked on #23** — based on `rerun-modifier` because the tests use `InlineOperation`. Retarget to `main` once that merges.

The "generic operation runtime" idea, to make shared modifiers something declared once rather than restated per call site.

## The gap

`OperationRunner` is generic over a *single* operation type, so it cannot run arbitrary operations. And `#run(op)` expands to `OperationRunner(operation:, initialContext: OperationContext())` — a **fresh context every invocation**. So on the stateless path there is nowhere for shared policy to live, and nothing established during one operation is visible to the next. `OperationClient` solves exactly this for stores; this is the same thing for runners.

```swift
let runtime = OperationRuntime(decorator: SupervisionDecorator())

let mux = try await runtime.run($launchMux(project))
let endpoint = try await runtime.run($bindEndpoint(mux.port))
```

## Why `OperationDecorator` is a protocol

A closure cannot be generic over the operation it decorates, and decoration has to preserve that operation's `Value` and `Failure`. A protocol with a generic method can; `OperationClient.StoreCreator` takes this shape for the same reason, so this follows the precedent rather than inventing one. It does mean users write a conforming type rather than passing a closure inline — worth knowing up front, since it is the main ergonomic cost.

The existential return type works because `OperationRequest` already declares `Value` and `Failure` as primary associated types. Typed throws and the `isolated` parameter both pass through it cleanly.

## Composition order

The runtime's modifiers wrap the operation's own. That means any modifier that already defines its own double-application behavior decides which wins — so an operation carrying `retry(limit: 1)` keeps its own limit against a runtime applying `retry(limit: 10)`, exactly as an operation overrides the retry behavior an `OperationClient` applies by default. There is a test pinning that (`anOperationsOwnRetryLimitTakesPrecedenceOverTheRuntimes`), since it is the property most likely to silently regress.

I deliberately did not touch `RetryOperation.swift` for this, given the work in flight there.

## One thing that may make this smaller than it looks

Much of what reads as duplicated *modifiers* is duplicated *context*. `backoff(_:)`, `delayer(_:)` and `clock(_:)` are `_ContextUpdatingOperationModifier`s that only write context values, so setting them on the runtime's `context` covers them with no decorator at all. The decorator is only needed for modifiers that genuinely wrap a run, like `retry`. That is documented on the type, since it is not obvious and it means many users need no decorator.

`setup` is invoked per call rather than once as in `OperationRunner`, because a runtime runs a different operation each time.

## Verification

505 tests in 41 suites pass, 25 known issues unchanged. Lint clean on the new files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)