### PR TITLE
Add OperationTransform for applying modifiers across a scope

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "bd6b935be610a20563678d6566aa5c7df276cf804f7aaf7f1ba29f2e569f8937",
+  "originHash" : "495cf62dc32d1a4149aaf61c993339628a15375848c5b08fa0ab53f19829bd03",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftwasm/JavaScriptKit",
       "state" : {
-        "revision" : "cadafdcf9a1946ed60dfd22407e7e8dd189920e8",
-        "version" : "0.58.0"
+        "revision" : "df32a66879cd5e1bbd12308d2fc248cf84fef5d3",
+        "version" : "0.50.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "495cf62dc32d1a4149aaf61c993339628a15375848c5b08fa0ab53f19829bd03",
+  "originHash" : "bd6b935be610a20563678d6566aa5c7df276cf804f7aaf7f1ba29f2e569f8937",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftwasm/JavaScriptKit",
       "state" : {
-        "revision" : "df32a66879cd5e1bbd12308d2fc248cf84fef5d3",
-        "version" : "0.50.0"
+        "revision" : "cadafdcf9a1946ed60dfd22407e7e8dd189920e8",
+        "version" : "0.58.0"
       }
     },
     {

--- a/Sources/OperationCore/AnyOperation.swift
+++ b/Sources/OperationCore/AnyOperation.swift
@@ -2,11 +2,19 @@
 public struct AnyOperation<Value, Failure: Error>: OperationRequest {
   /// An existential to the erased operation.
   public let base: any OperationRequest<Value, Failure>
-  
+
   /// Type erases an ``OperationRequest``.
   ///
   /// - Parameter operation: The operation to erase.
   public init(_ operation: some OperationRequest<Value, Failure>) {
+    self.base = operation
+  }
+
+  /// Type erases an ``OperationRequest``.
+  ///
+  /// - Parameter operation: The operation to erase.
+  @_disfavoredOverload
+  public init(_ operation: any OperationRequest<Value, Failure>) {
     self.base = operation
   }
 

--- a/Sources/OperationCore/OperationRunner.swift
+++ b/Sources/OperationCore/OperationRunner.swift
@@ -65,25 +65,12 @@ public struct OperationRunner<Operation: OperationRequest> {
     let context = context ?? self.context
     let transforms = operationTransforms
     guard !transforms.isEmpty else {
-      return try await self.operation.run(
-        isolation: isolation,
-        in: context,
-        with: continuation
-      )
+      return try await self.operation.run(isolation: isolation, in: context, with: continuation)
     }
-    // Transforms are applied here rather than in `init`, because they add modifiers that need
-    // setting up, and a modifier may carry per-instance identity that would differ between two
-    // applications. `_RetryModifier` does: applying a transform once to set up and again to run
-    // would leave the context holding a retryer id that no longer matches any modifier, and
-    // retrying would silently stop happening.
     let transformed = transforms.applied(to: self.operation)
-    var transformedContext = context
-    transformed.setup(context: &transformedContext)
-    return try await transformed.run(
-      isolation: isolation,
-      in: transformedContext,
-      with: continuation
-    )
+    var runContext = context
+    transformed.setup(context: &runContext)
+    return try await transformed.run(isolation: isolation, in: runContext, with: continuation)
   }
 }
 

--- a/Sources/OperationCore/OperationRunner.swift
+++ b/Sources/OperationCore/OperationRunner.swift
@@ -44,6 +44,11 @@ public struct OperationRunner<Operation: OperationRequest> {
 
   /// Runs the underlying operation of this runner.
   ///
+  /// If an ``OperationTransform`` is in scope for the current task, its modifiers are applied to
+  /// the operation for this run, and ``OperationRequest/setup(context:)-8y79v`` is invoked on the
+  /// result. Setup therefore reaches the underlying operation a second time in that case, on a
+  /// context that already reflects it.
+  ///
   /// - Parameters:
   ///   - isolation: The current actor-isolation of this operation run.
   ///   - context: The ``OperationContext`` to pass to the operation run. (Defaults to the
@@ -57,9 +62,25 @@ public struct OperationRunner<Operation: OperationRequest> {
     with continuation: OperationContinuation<Operation.Value, Operation.Failure> =
       OperationContinuation { _, _ in }
   ) async throws(Operation.Failure) -> Operation.Value {
-    try await self.operation.run(
+    let context = context ?? self.context
+    guard let transform = currentOperationTransform else {
+      return try await self.operation.run(
+        isolation: isolation,
+        in: context,
+        with: continuation
+      )
+    }
+    // The transform is applied here rather than in `init`, because it adds modifiers that need
+    // setting up, and a modifier may carry per-instance identity that would differ between two
+    // applications. `_RetryModifier` does: applying a transform once to set up and again to run
+    // would leave the context holding a retryer id that no longer matches any modifier, and
+    // retrying would silently stop happening.
+    let transformed = transform.apply(to: self.operation)
+    var transformedContext = context
+    transformed.setup(context: &transformedContext)
+    return try await transformed.run(
       isolation: isolation,
-      in: context ?? self.context,
+      in: transformedContext,
       with: continuation
     )
   }

--- a/Sources/OperationCore/OperationRunner.swift
+++ b/Sources/OperationCore/OperationRunner.swift
@@ -44,7 +44,7 @@ public struct OperationRunner<Operation: OperationRequest> {
 
   /// Runs the underlying operation of this runner.
   ///
-  /// If an ``OperationTransform`` is in scope for the current task, its modifiers are applied to
+  /// Any ``OperationTransform``s in scope for the current task have their modifiers applied to
   /// the operation for this run, and ``OperationRequest/setup(context:)-8y79v`` is invoked on the
   /// result. Setup therefore reaches the underlying operation a second time in that case, on a
   /// context that already reflects it.
@@ -63,19 +63,20 @@ public struct OperationRunner<Operation: OperationRequest> {
       OperationContinuation { _, _ in }
   ) async throws(Operation.Failure) -> Operation.Value {
     let context = context ?? self.context
-    guard let transform = currentOperationTransform else {
+    let transforms = operationTransforms
+    guard !transforms.isEmpty else {
       return try await self.operation.run(
         isolation: isolation,
         in: context,
         with: continuation
       )
     }
-    // The transform is applied here rather than in `init`, because it adds modifiers that need
+    // Transforms are applied here rather than in `init`, because they add modifiers that need
     // setting up, and a modifier may carry per-instance identity that would differ between two
     // applications. `_RetryModifier` does: applying a transform once to set up and again to run
     // would leave the context holding a retryer id that no longer matches any modifier, and
     // retrying would silently stop happening.
-    let transformed = transform.apply(to: self.operation)
+    let transformed = transforms.applied(to: self.operation)
     var transformedContext = context
     transformed.setup(context: &transformedContext)
     return try await transformed.run(

--- a/Sources/OperationCore/OperationTransform.swift
+++ b/Sources/OperationCore/OperationTransform.swift
@@ -1,0 +1,102 @@
+// MARK: - OperationTransform
+
+/// A set of modifiers applied to every operation run within a scope.
+///
+/// Operations that share behavior usually restate it at every call site. A transform states it
+/// once, and ``withOperationTransform(_:isolation:operation:)`` decides where it applies.
+///
+/// ```swift
+/// struct SupervisionTransform: OperationTransform {
+///   func apply<Operation: OperationRequest>(
+///     to operation: Operation
+///   ) -> any OperationRequest<Operation.Value, Operation.Failure> {
+///     operation.retry(limit: 3)
+///       .backoff(.exponential(.milliseconds(50)).jittered())
+///   }
+/// }
+///
+/// try await withOperationTransform(SupervisionTransform()) {
+///   let mux = try await #run($launchMux(project))
+///   let endpoint = try await #run($bindEndpoint(mux.port))
+/// }
+/// ```
+///
+/// This is a protocol rather than a closure because a closure cannot be generic over the operation
+/// it is applied to, and the result has to preserve that operation's `Value` and `Failure`.
+/// ``OperationClient/StoreCreator`` takes the same shape for the same reason.
+///
+/// A transform's modifiers wrap the operation's own. Any modifier that defines what happens when
+/// it is applied twice therefore decides which one wins: an operation carrying
+/// ``OperationRequest/retry(limit:)`` keeps its own limit rather than the transform's, in the same
+/// way that an operation overrides the retry behavior an ``OperationClient`` applies by default.
+public protocol OperationTransform: Sendable {
+  /// Applies this transform's modifiers to an operation.
+  ///
+  /// This method is called once per run, and must be free of side effects. Modifiers are allowed
+  /// to carry per-instance identity — ``OperationRequest/retry(limit:)`` does, to detect being
+  /// applied twice — so applying a transform is not something the library can safely do more than
+  /// once for the same run.
+  ///
+  /// - Parameter operation: The operation being run.
+  /// - Returns: `operation` with this transform's modifiers applied.
+  func apply<Operation: OperationRequest>(
+    to operation: Operation
+  ) -> any OperationRequest<Operation.Value, Operation.Failure>
+}
+
+// MARK: - Current Transform
+
+private enum CurrentOperationTransform {
+  @TaskLocal static var value: (any OperationTransform)?
+}
+
+/// The ``OperationTransform`` applied to operations run by the current task, or nil when no
+/// transform is in scope.
+///
+/// Read this to compose a transform with the one already in scope, rather than replacing it.
+///
+/// ```swift
+/// struct LoggingTransform: OperationTransform {
+///   let base: (any OperationTransform)?
+///
+///   func apply<Operation: OperationRequest>(
+///     to operation: Operation
+///   ) -> any OperationRequest<Operation.Value, Operation.Failure> {
+///     let operation = self.base?.apply(to: operation) ?? operation
+///     return operation.logDuration()
+///   }
+/// }
+///
+/// try await withOperationTransform(LoggingTransform(base: currentOperationTransform)) {
+///   // ...
+/// }
+/// ```
+public var currentOperationTransform: (any OperationTransform)? {
+  CurrentOperationTransform.value
+}
+
+/// Applies an ``OperationTransform`` to every operation run within `operation`.
+///
+/// The transform reaches every operation run in the body, including ones run by child tasks,
+/// without being threaded through the code between. Operations run outside the body are
+/// unaffected.
+///
+/// A nested call replaces the transform for its own body rather than composing with it. Read
+/// ``currentOperationTransform`` to compose deliberately.
+///
+/// - Parameters:
+///   - transform: The ``OperationTransform`` to apply.
+///   - isolation: The current actor-isolation.
+///   - operation: The body to run the transform for.
+/// - Returns: Whatever `operation` returns.
+public func withOperationTransform<T>(
+  _ transform: some OperationTransform,
+  isolation: isolated (any Actor)? = #isolation,
+  operation: () async throws -> T
+) async rethrows -> T {
+  try await CurrentOperationTransform.$value.withValue(
+    transform,
+    operation: operation,
+    isolation: isolation
+  )
+}

--- a/Sources/OperationCore/OperationTransform.swift
+++ b/Sources/OperationCore/OperationTransform.swift
@@ -28,38 +28,44 @@ public protocol OperationTransform: Sendable {
   ) -> any OperationRequest<Operation.Value, Operation.Failure>
 }
 
-// MARK: - Current Transform
+// MARK: - Applying
 
-private enum CurrentOperationTransform {
-  @TaskLocal static var value: (any OperationTransform)?
+extension [any OperationTransform] {
+  func applied<Operation: OperationRequest>(
+    to operation: Operation
+  ) -> any OperationRequest<Operation.Value, Operation.Failure> {
+    self.reversed()
+      .reduce(AnyOperation(operation)) { transformed, transform in
+        AnyOperation(transform.apply(to: transformed))
+      }
+  }
 }
 
-/// The ``OperationTransform`` applied to operations run by the current task, or nil when no
-/// transform is in scope.
-///
-/// Read this to compose a transform with the one already in scope, rather than replacing it.
+// MARK: - Current Transforms
+
+private enum CurrentOperationTransforms {
+  @TaskLocal static var value = [any OperationTransform]()
+}
+
+/// The ``OperationTransform``s applied to operations run by the current task, outermost first.
 ///
 /// ```swift
-/// struct LoggingTransform: OperationTransform {
-///   let base: (any OperationTransform)?
-///
-///   func apply<Operation: OperationRequest>(
-///     to operation: Operation
-///   ) -> any OperationRequest<Operation.Value, Operation.Failure> {
-///     let operation = self.base?.apply(to: operation) ?? operation
-///     return operation.logDuration()
+/// try await withOperationTransform(SupervisionTransform()) {
+///   let transforms = operationTransforms
+///   Task.detached {
+///     // The transforms do not cross this boundary on their own.
+///     try await withOperationTransforms(transforms) {
+///       try await #run($launchMux(project))
+///     }
 ///   }
 /// }
-///
-/// try await withOperationTransform(LoggingTransform(base: currentOperationTransform)) {
-///   // ...
-/// }
 /// ```
-public var currentOperationTransform: (any OperationTransform)? {
-  CurrentOperationTransform.value
+public var operationTransforms: [any OperationTransform] {
+  CurrentOperationTransforms.value
 }
 
-/// Applies an ``OperationTransform`` to every operation run within `operation`.
+/// Applies an ``OperationTransform`` to every operation run within `operation`, in addition to
+/// those already in scope.
 ///
 /// ```swift
 /// struct SupervisionTransform: OperationTransform {
@@ -74,22 +80,56 @@ public var currentOperationTransform: (any OperationTransform)? {
 /// try await withOperationTransform(SupervisionTransform()) {
 ///   // Each operation has 3 retries and exponential backoff with jitter
 ///   let mux = try await #run($launchMux(project))
-///   let endpoint = try await #run($bindEndpoint(mux.port))
+///
+///   try await withOperationTransform(LoggingTransform()) {
+///     // And this operation is logged as well
+///     let endpoint = try await #run($bindEndpoint(mux.port))
+///   }
 /// }
 /// ```
 ///
 /// - Parameters:
 ///   - transform: The ``OperationTransform`` to apply.
 ///   - isolation: The current actor-isolation.
-///   - operation: The body to run the transform for.
+///   - operation: The body to apply the transform to.
 /// - Returns: Whatever `operation` returns.
 public func withOperationTransform<T>(
   _ transform: some OperationTransform,
   isolation: isolated (any Actor)? = #isolation,
   operation: () async throws -> T
 ) async rethrows -> T {
-  try await CurrentOperationTransform.$value.withValue(
-    transform,
+  try await withOperationTransforms(
+    operationTransforms + [transform],
+    isolation: isolation,
+    operation: operation
+  )
+}
+
+/// Applies exactly the specified ``OperationTransform``s to every operation run within
+/// `operation`, replacing any already in scope.
+///
+/// Transforms are applied innermost last, so the final element of `transforms` ends up closest to
+/// the operation.
+///
+/// ```swift
+/// // Nothing in scope is applied within the body.
+/// try await withOperationTransforms([]) {
+///   let mux = try await #run($launchMux(project))
+/// }
+/// ```
+///
+/// - Parameters:
+///   - transforms: The ``OperationTransform``s to apply.
+///   - isolation: The current actor-isolation.
+///   - operation: The body to apply the transforms to.
+/// - Returns: Whatever `operation` returns.
+public func withOperationTransforms<T>(
+  _ transforms: some Sequence<any OperationTransform>,
+  isolation: isolated (any Actor)? = #isolation,
+  operation: () async throws -> T
+) async rethrows -> T {
+  try await CurrentOperationTransforms.$value.withValue(
+    Array(transforms),
     operation: operation,
     isolation: isolation
   )

--- a/Sources/OperationCore/OperationTransform.swift
+++ b/Sources/OperationCore/OperationTransform.swift
@@ -31,12 +31,6 @@ public protocol OperationTransform: Sendable {
 // MARK: - Applying
 
 extension [any OperationTransform] {
-  /// `operation` with each of these transforms applied, the last of them closest to `operation`.
-  ///
-  /// The transform nearest the operation receives it as its own concrete type, so an operation
-  /// run under a single transform is never boxed. Only the transforms above that one need an
-  /// `AnyOperation` to fold through, because an `any OperationRequest` does not open implicitly
-  /// when passed back into ``OperationTransform/apply(to:)``.
   func applied<Operation: OperationRequest>(
     to operation: Operation
   ) -> any OperationRequest<Operation.Value, Operation.Failure> {

--- a/Sources/OperationCore/OperationTransform.swift
+++ b/Sources/OperationCore/OperationTransform.swift
@@ -64,8 +64,20 @@ public var operationTransforms: [any OperationTransform] {
   CurrentOperationTransforms.value
 }
 
-/// Applies an ``OperationTransform`` to every operation run within `operation`, in addition to
-/// those already in scope.
+// MARK: - Behavior
+
+/// How a scope's ``OperationTransform``s combine with the ones already in scope.
+public enum OperationTransformBehavior: Hashable, Sendable {
+  /// Adds to the transforms already in scope.
+  case append
+
+  /// Replaces the transforms already in scope.
+  case override
+}
+
+// MARK: - Scoping
+
+/// Applies an ``OperationTransform`` to every operation run within `operation`.
 ///
 /// ```swift
 /// struct SupervisionTransform: OperationTransform {
@@ -85,33 +97,48 @@ public var operationTransforms: [any OperationTransform] {
 ///     // And this operation is logged as well
 ///     let endpoint = try await #run($bindEndpoint(mux.port))
 ///   }
+///
+///   try await withOperationTransform(LoggingTransform(), behavior: .override) {
+///     // Whilst this operation is only logged
+///     let status = try await #run($muxStatus(mux.port))
+///   }
 /// }
 /// ```
 ///
 /// - Parameters:
 ///   - transform: The ``OperationTransform`` to apply.
+///   - behavior: Whether `transform` adds to the transforms in scope, or replaces them.
 ///   - isolation: The current actor-isolation.
 ///   - operation: The body to apply the transform to.
 /// - Returns: Whatever `operation` returns.
 public func withOperationTransform<T>(
   _ transform: some OperationTransform,
+  behavior: OperationTransformBehavior = .append,
   isolation: isolated (any Actor)? = #isolation,
   operation: () async throws -> T
 ) async rethrows -> T {
   try await withOperationTransforms(
-    operationTransforms + [transform],
+    [transform],
+    behavior: behavior,
     isolation: isolation,
     operation: operation
   )
 }
 
-/// Applies exactly the specified ``OperationTransform``s to every operation run within
-/// `operation`, replacing any already in scope.
+/// Applies ``OperationTransform``s to every operation run within `operation`.
 ///
 /// Transforms are applied innermost last, so the final element of `transforms` ends up closest to
 /// the operation.
 ///
 /// ```swift
+/// // The transforms in scope do not cross this boundary on their own.
+/// let transforms = operationTransforms
+/// Task.detached {
+///   try await withOperationTransforms(transforms) {
+///     try await #run($launchMux(project))
+///   }
+/// }
+///
 /// // Nothing in scope is applied within the body.
 /// try await withOperationTransforms([]) {
 ///   let mux = try await #run($launchMux(project))
@@ -120,16 +147,23 @@ public func withOperationTransform<T>(
 ///
 /// - Parameters:
 ///   - transforms: The ``OperationTransform``s to apply.
+///   - behavior: Whether `transforms` add to the transforms in scope, or replace them.
 ///   - isolation: The current actor-isolation.
 ///   - operation: The body to apply the transforms to.
 /// - Returns: Whatever `operation` returns.
 public func withOperationTransforms<T>(
   _ transforms: some Sequence<any OperationTransform>,
+  behavior: OperationTransformBehavior = .override,
   isolation: isolated (any Actor)? = #isolation,
   operation: () async throws -> T
 ) async rethrows -> T {
-  try await CurrentOperationTransforms.$value.withValue(
-    Array(transforms),
+  let applied =
+    switch behavior {
+    case .append: operationTransforms + Array(transforms)
+    case .override: Array(transforms)
+    }
+  return try await CurrentOperationTransforms.$value.withValue(
+    applied,
     operation: operation,
     isolation: isolation
   )

--- a/Sources/OperationCore/OperationTransform.swift
+++ b/Sources/OperationCore/OperationTransform.swift
@@ -2,9 +2,6 @@
 
 /// A set of modifiers applied to every operation run within a scope.
 ///
-/// Operations that share behavior usually restate it at every call site. A transform states it
-/// once, and ``withOperationTransform(_:isolation:operation:)`` decides where it applies.
-///
 /// ```swift
 /// struct SupervisionTransform: OperationTransform {
 ///   func apply<Operation: OperationRequest>(
@@ -16,26 +13,13 @@
 /// }
 ///
 /// try await withOperationTransform(SupervisionTransform()) {
+///   // Each operation has 3 retries and exponential backoff with jitter
 ///   let mux = try await #run($launchMux(project))
 ///   let endpoint = try await #run($bindEndpoint(mux.port))
 /// }
 /// ```
-///
-/// This is a protocol rather than a closure because a closure cannot be generic over the operation
-/// it is applied to, and the result has to preserve that operation's `Value` and `Failure`.
-/// ``OperationClient/StoreCreator`` takes the same shape for the same reason.
-///
-/// A transform's modifiers wrap the operation's own. Any modifier that defines what happens when
-/// it is applied twice therefore decides which one wins: an operation carrying
-/// ``OperationRequest/retry(limit:)`` keeps its own limit rather than the transform's, in the same
-/// way that an operation overrides the retry behavior an ``OperationClient`` applies by default.
 public protocol OperationTransform: Sendable {
   /// Applies this transform's modifiers to an operation.
-  ///
-  /// This method is called once per run, and must be free of side effects. Modifiers are allowed
-  /// to carry per-instance identity — ``OperationRequest/retry(limit:)`` does, to detect being
-  /// applied twice — so applying a transform is not something the library can safely do more than
-  /// once for the same run.
   ///
   /// - Parameter operation: The operation being run.
   /// - Returns: `operation` with this transform's modifiers applied.
@@ -77,12 +61,22 @@ public var currentOperationTransform: (any OperationTransform)? {
 
 /// Applies an ``OperationTransform`` to every operation run within `operation`.
 ///
-/// The transform reaches every operation run in the body, including ones run by child tasks,
-/// without being threaded through the code between. Operations run outside the body are
-/// unaffected.
+/// ```swift
+/// struct SupervisionTransform: OperationTransform {
+///   func apply<Operation: OperationRequest>(
+///     to operation: Operation
+///   ) -> any OperationRequest<Operation.Value, Operation.Failure> {
+///     operation.retry(limit: 3)
+///       .backoff(.exponential(.milliseconds(50)).jittered())
+///   }
+/// }
 ///
-/// A nested call replaces the transform for its own body rather than composing with it. Read
-/// ``currentOperationTransform`` to compose deliberately.
+/// try await withOperationTransform(SupervisionTransform()) {
+///   // Each operation has 3 retries and exponential backoff with jitter
+///   let mux = try await #run($launchMux(project))
+///   let endpoint = try await #run($bindEndpoint(mux.port))
+/// }
+/// ```
 ///
 /// - Parameters:
 ///   - transform: The ``OperationTransform`` to apply.

--- a/Sources/OperationCore/OperationTransform.swift
+++ b/Sources/OperationCore/OperationTransform.swift
@@ -98,12 +98,12 @@ public enum OperationTransformBehavior: Hashable, Sendable {
 ///   let mux = try await #run($launchMux(project))
 ///
 ///   try await withOperationTransform(LoggingTransform()) {
-///     // And this operation is logged as well
+///     // This operation is logged alongside having retries
 ///     let endpoint = try await #run($bindEndpoint(mux.port))
 ///   }
 ///
 ///   try await withOperationTransform(LoggingTransform(), behavior: .override) {
-///     // Whilst this operation is only logged
+///     // This operation is only logged
 ///     let status = try await #run($muxStatus(mux.port))
 ///   }
 /// }

--- a/Sources/OperationCore/OperationTransform.swift
+++ b/Sources/OperationCore/OperationTransform.swift
@@ -31,11 +31,21 @@ public protocol OperationTransform: Sendable {
 // MARK: - Applying
 
 extension [any OperationTransform] {
+  /// `operation` with each of these transforms applied, the last of them closest to `operation`.
+  ///
+  /// The transform nearest the operation receives it as its own concrete type, so an operation
+  /// run under a single transform is never boxed. Only the transforms above that one need an
+  /// `AnyOperation` to fold through, because an `any OperationRequest` does not open implicitly
+  /// when passed back into ``OperationTransform/apply(to:)``.
   func applied<Operation: OperationRequest>(
     to operation: Operation
   ) -> any OperationRequest<Operation.Value, Operation.Failure> {
-    self.reversed()
-      .reduce(AnyOperation(operation)) { transformed, transform in
+    guard let innermost = self.last else { return operation }
+    let applied = innermost.apply(to: operation)
+    guard self.count > 1 else { return applied }
+    return self.dropLast()
+      .reversed()
+      .reduce(AnyOperation(applied)) { transformed, transform in
         AnyOperation(transform.apply(to: transformed))
       }
   }

--- a/Tests/OperationTests/OperationTransformTests.swift
+++ b/Tests/OperationTests/OperationTransformTests.swift
@@ -118,6 +118,37 @@ struct OperationTransformTests {
     expectNoDifference(recorder.tags, ["only"])
   }
 
+  @Test("Overrides The Transforms In Scope With A Single Transform")
+  func overridesTheTransformsInScopeWithASingleTransform() async {
+    let recorder = TagRecorder()
+    await withOperationTransform(TaggingTransform(tag: "outer", recorder: recorder)) {
+      await withOperationTransform(
+        TaggingTransform(tag: "only", recorder: recorder),
+        behavior: .override
+      ) {
+        _ = await #run(ConstantOperation(value: 1))
+      }
+    }
+    expectNoDifference(recorder.tags, ["only"])
+  }
+
+  @Test("Appends A Sequence To The Transforms In Scope")
+  func appendsASequenceToTheTransformsInScope() async {
+    let recorder = TagRecorder()
+    await withOperationTransform(TaggingTransform(tag: "outer", recorder: recorder)) {
+      await withOperationTransforms(
+        [
+          TaggingTransform(tag: "first", recorder: recorder),
+          TaggingTransform(tag: "second", recorder: recorder)
+        ],
+        behavior: .append
+      ) {
+        _ = await #run(ConstantOperation(value: 1))
+      }
+    }
+    expectNoDifference(recorder.tags, ["outer", "first", "second"])
+  }
+
   @Test("Applies Nothing When Given An Empty Sequence")
   func appliesNothingWhenGivenAnEmptySequence() async {
     let counter = RunCounter()

--- a/Tests/OperationTests/OperationTransformTests.swift
+++ b/Tests/OperationTests/OperationTransformTests.swift
@@ -70,17 +70,80 @@ struct OperationTransformTests {
     expectNoDifference(counter.count, 2)
   }
 
-  @Test("A Nested Transform Replaces The One Around It")
-  func aNestedTransformReplacesTheOneAroundIt() async {
+  @Test("A Nested Transform Composes With The One Around It")
+  func aNestedTransformComposesWithTheOneAroundIt() async {
+    let recorder = TagRecorder()
+    await withOperationTransform(TaggingTransform(tag: "outer", recorder: recorder)) {
+      await withOperationTransform(TaggingTransform(tag: "inner", recorder: recorder)) {
+        _ = await #run(ConstantOperation(value: 1))
+      }
+    }
+    expectNoDifference(recorder.tags, ["outer", "inner"])
+  }
+
+  @Test("Applies The Innermost Transform Closest To The Operation")
+  func appliesTheInnermostTransformClosestToTheOperation() async {
+    let recorder = TagRecorder()
+    await withOperationTransforms([
+      TaggingTransform(tag: "first", recorder: recorder),
+      TaggingTransform(tag: "second", recorder: recorder)
+    ]) {
+      _ = await #run(ConstantOperation(value: 1))
+    }
+    // Modifiers run outermost first, so the last transform given is the one nearest the operation.
+    expectNoDifference(recorder.tags, ["first", "second"])
+  }
+
+  @Test("Reports The Transforms In Scope, Outermost First")
+  func reportsTheTransformsInScopeOutermostFirst() async {
+    let recorder = TagRecorder()
+    expectNoDifference(operationTransforms.count, 0)
+    await withOperationTransform(TaggingTransform(tag: "outer", recorder: recorder)) {
+      await withOperationTransform(TaggingTransform(tag: "inner", recorder: recorder)) {
+        let tags = operationTransforms.compactMap { ($0 as? TaggingTransform)?.tag }
+        expectNoDifference(tags, ["outer", "inner"])
+      }
+    }
+    expectNoDifference(operationTransforms.count, 0)
+  }
+
+  @Test("Replaces The Transforms In Scope With An Explicit Sequence")
+  func replacesTheTransformsInScopeWithAnExplicitSequence() async {
+    let recorder = TagRecorder()
+    await withOperationTransform(TaggingTransform(tag: "outer", recorder: recorder)) {
+      await withOperationTransforms([TaggingTransform(tag: "only", recorder: recorder)]) {
+        _ = await #run(ConstantOperation(value: 1))
+      }
+    }
+    expectNoDifference(recorder.tags, ["only"])
+  }
+
+  @Test("Applies Nothing When Given An Empty Sequence")
+  func appliesNothingWhenGivenAnEmptySequence() async {
     let counter = RunCounter()
-    await withOperationTransform(RetryingTransform(limit: 10)) {
-      await withOperationTransform(RetryingTransform(limit: 1)) {
+    await withOperationTransform(RetryingTransform(limit: 3)) {
+      await withOperationTransforms([]) {
         await #expect(throws: SomeError.self) {
           try await #run(FailingOperation(counter: counter))
         }
       }
     }
-    expectNoDifference(counter.count, 2)
+    expectNoDifference(counter.count, 1)
+  }
+
+  @Test("Carries The Transforms In Scope Across A Detached Task")
+  func carriesTheTransformsInScopeAcrossADetachedTask() async {
+    let counter = RunCounter()
+    let carried = await withOperationTransform(RetryingTransform(limit: 3)) {
+      operationTransforms
+    }
+    await Task.detached {
+      await withOperationTransforms(carried) {
+        _ = try? await #run(FailingOperation(counter: counter))
+      }
+    }
+    .value
+    expectNoDifference(counter.count, 4)
   }
 
   @Test("Reaches Operations Run By Child Tasks")
@@ -113,19 +176,6 @@ struct OperationTransformTests {
     expectNoDifference(value, 2)
     expectNoDifference(yielded.withLock { $0 }, [1])
   }
-
-  @Test("Composes With The Transform Already In Scope When Asked To")
-  func composesWithTheTransformAlreadyInScopeWhenAskedTo() async {
-    let counter = RunCounter()
-    await withOperationTransform(RetryingTransform(limit: 2)) {
-      await withOperationTransform(ComposedTransform(base: currentOperationTransform)) {
-        await #expect(throws: SomeError.self) {
-          try await #run(FailingOperation(counter: counter))
-        }
-      }
-    }
-    expectNoDifference(counter.count, 3)
-  }
 }
 
 // MARK: - Helpers
@@ -142,15 +192,42 @@ private struct RetryingTransform: OperationTransform {
   }
 }
 
-/// A transform that adds nothing of its own, so that what reaches the operation is whatever the
-/// transform it was composed with contributes.
-private struct ComposedTransform: OperationTransform {
-  let base: (any OperationTransform)?
+/// Records a tag when the operation it wraps runs, so that composition order is observable.
+private struct TaggingTransform: OperationTransform {
+  let tag: String
+  let recorder: TagRecorder
 
   func apply<Operation: OperationRequest>(
     to operation: Operation
   ) -> any OperationRequest<Operation.Value, Operation.Failure> {
-    self.base?.apply(to: operation) ?? operation
+    operation.modifier(TaggingModifier(tag: self.tag, recorder: self.recorder))
+  }
+}
+
+private struct TaggingModifier<Operation: OperationRequest>: OperationModifier, Sendable {
+  let tag: String
+  let recorder: TagRecorder
+
+  func run(
+    isolation: isolated (any Actor)?,
+    in context: OperationContext,
+    using operation: Operation,
+    with continuation: OperationContinuation<Operation.Value, Operation.Failure>
+  ) async throws(Operation.Failure) -> Operation.Value {
+    self.recorder.append(self.tag)
+    return try await operation.run(isolation: isolation, in: context, with: continuation)
+  }
+}
+
+private final class TagRecorder: Sendable {
+  private let _tags = RecursiveLock([String]())
+
+  var tags: [String] {
+    self._tags.withLock { $0 }
+  }
+
+  func append(_ tag: String) {
+    self._tags.withLock { $0.append(tag) }
   }
 }
 

--- a/Tests/OperationTests/OperationTransformTests.swift
+++ b/Tests/OperationTests/OperationTransformTests.swift
@@ -149,11 +149,36 @@ struct OperationTransformTests {
     expectNoDifference(recorder.tags, ["outer", "first", "second"])
   }
 
+  @Test("Hands A Single Transform The Operation's Own Type")
+  func handsASingleTransformTheOperationsOwnType() async {
+    let recorder = TagRecorder()
+    await withOperationTransform(OperandNamingTransform(recorder: recorder)) {
+      _ = await #run(ConstantOperation(value: 1))
+    }
+    expectNoDifference(recorder.tags.count, 1)
+    expectNoDifference(recorder.tags[0].contains("AnyOperation"), false)
+    expectNoDifference(recorder.tags[0].contains("ConstantOperation"), true)
+  }
+
+  @Test("Hands The Innermost Of Several Transforms The Operation's Own Type")
+  func handsTheInnermostOfSeveralTransformsTheOperationsOwnType() async {
+    let recorder = TagRecorder()
+    let transforms: [any OperationTransform] = [
+      TaggingTransform(tag: "outer", recorder: recorder),
+      OperandNamingTransform(recorder: recorder)
+    ]
+    await withOperationTransforms(transforms) {
+      _ = await #run(ConstantOperation(value: 1))
+    }
+    expectNoDifference(recorder.tags.last?.contains("AnyOperation"), false)
+    expectNoDifference(recorder.tags.last?.contains("ConstantOperation"), true)
+  }
+
   @Test("Applies Nothing When Given An Empty Sequence")
   func appliesNothingWhenGivenAnEmptySequence() async {
     let counter = RunCounter()
     await withOperationTransform(RetryingTransform(limit: 3)) {
-      await withOperationTransforms([]) {
+      _ = await withOperationTransforms([]) {
         await #expect(throws: SomeError.self) {
           try await #run(FailingOperation(counter: counter))
         }
@@ -232,6 +257,31 @@ private struct TaggingTransform: OperationTransform {
     to operation: Operation
   ) -> any OperationRequest<Operation.Value, Operation.Failure> {
     operation.modifier(TaggingModifier(tag: self.tag, recorder: self.recorder))
+  }
+}
+
+/// Records the type name of the operation it wraps, so that erasure of the operand is observable.
+private struct OperandNamingTransform: OperationTransform {
+  let recorder: TagRecorder
+
+  func apply<Operation: OperationRequest>(
+    to operation: Operation
+  ) -> any OperationRequest<Operation.Value, Operation.Failure> {
+    operation.modifier(OperandNamingModifier(recorder: self.recorder))
+  }
+}
+
+private struct OperandNamingModifier<Operation: OperationRequest>: OperationModifier, Sendable {
+  let recorder: TagRecorder
+
+  func run(
+    isolation: isolated (any Actor)?,
+    in context: OperationContext,
+    using operation: Operation,
+    with continuation: OperationContinuation<Operation.Value, Operation.Failure>
+  ) async throws(Operation.Failure) -> Operation.Value {
+    self.recorder.append(operation._debugTypeName)
+    return try await operation.run(isolation: isolation, in: context, with: continuation)
   }
 }
 

--- a/Tests/OperationTests/OperationTransformTests.swift
+++ b/Tests/OperationTests/OperationTransformTests.swift
@@ -1,0 +1,213 @@
+import CustomDump
+import Operation
+import Testing
+
+@Suite("OperationTransform tests")
+struct OperationTransformTests {
+  @Test("Does Not Apply A Transform When None Is In Scope")
+  func doesNotApplyATransformWhenNoneIsInScope() async {
+    let counter = RunCounter()
+    await #expect(throws: SomeError.self) {
+      try await #run(FailingOperation(counter: counter))
+    }
+    expectNoDifference(counter.count, 1)
+  }
+
+  @Test("Applies The Transform In Scope To A Run")
+  func appliesTheTransformInScopeToARun() async {
+    let counter = RunCounter()
+    await withOperationTransform(RetryingTransform(limit: 3)) {
+      await #expect(throws: SomeError.self) {
+        try await #run(FailingOperation(counter: counter))
+      }
+    }
+    expectNoDifference(counter.count, 4)
+  }
+
+  @Test("Does Not Apply The Transform After Its Scope Ends")
+  func doesNotApplyTheTransformAfterItsScopeEnds() async {
+    let counter = RunCounter()
+    await withOperationTransform(RetryingTransform(limit: 3)) {}
+    await #expect(throws: SomeError.self) {
+      try await #run(FailingOperation(counter: counter))
+    }
+    expectNoDifference(counter.count, 1)
+  }
+
+  @Test("Applies The Transform To Operations Of Differing Value And Failure Types")
+  func appliesTheTransformToOperationsOfDifferingValueAndFailureTypes() async {
+    await withOperationTransform(RetryingTransform(limit: 1)) {
+      let number = await #run(ConstantOperation(value: 1))
+      let text = await #run(ConstantOperation(value: "blob"))
+      expectNoDifference(number, 1)
+      expectNoDifference(text, "blob")
+    }
+  }
+
+  @Test("Sets Up The Transform's Modifiers")
+  func setsUpTheTransformsModifiers() async {
+    // `retry(limit:)` writes its limit into the context during setup, so the operation can only
+    // read back 4 if the transform's modifiers were set up.
+    let limit = await withOperationTransform(RetryingTransform(limit: 4)) {
+      await #run(MaxRetriesOperation())
+    }
+    expectNoDifference(limit, 4)
+  }
+
+  @Test("An Operation's Own Retry Limit Takes Precedence Over The Transform's")
+  func anOperationsOwnRetryLimitTakesPrecedenceOverTheTransforms() async {
+    let counter = RunCounter()
+    await withOperationTransform(RetryingTransform(limit: 10)) {
+      await #expect(throws: SomeError.self) {
+        try await #run(
+          FailingOperation(counter: counter)
+            .retry(limit: 1)
+            .backoff(.noBackoff)
+            .delayer(.noDelay)
+        )
+      }
+    }
+    expectNoDifference(counter.count, 2)
+  }
+
+  @Test("A Nested Transform Replaces The One Around It")
+  func aNestedTransformReplacesTheOneAroundIt() async {
+    let counter = RunCounter()
+    await withOperationTransform(RetryingTransform(limit: 10)) {
+      await withOperationTransform(RetryingTransform(limit: 1)) {
+        await #expect(throws: SomeError.self) {
+          try await #run(FailingOperation(counter: counter))
+        }
+      }
+    }
+    expectNoDifference(counter.count, 2)
+  }
+
+  @Test("Reaches Operations Run By Child Tasks")
+  func reachesOperationsRunByChildTasks() async {
+    let counter = RunCounter()
+    await withOperationTransform(RetryingTransform(limit: 3)) {
+      await withTaskGroup(of: Void.self) { group in
+        group.addTask {
+          _ = try? await #run(FailingOperation(counter: counter))
+        }
+        await group.waitForAll()
+      }
+    }
+    expectNoDifference(counter.count, 4)
+  }
+
+  @Test("Yields Values Through The Continuation Under A Transform")
+  func yieldsValuesThroughTheContinuationUnderATransform() async {
+    let yielded = RecursiveLock([Int]())
+    let value = await withOperationTransform(RetryingTransform(limit: 1)) {
+      await #run(
+        YieldingOperation(),
+        context: OperationContext(),
+        continuation: OperationContinuation { result, _ in
+          guard case .success(let next) = result else { return }
+          yielded.withLock { $0.append(next) }
+        }
+      )
+    }
+    expectNoDifference(value, 2)
+    expectNoDifference(yielded.withLock { $0 }, [1])
+  }
+
+  @Test("Composes With The Transform Already In Scope When Asked To")
+  func composesWithTheTransformAlreadyInScopeWhenAskedTo() async {
+    let counter = RunCounter()
+    await withOperationTransform(RetryingTransform(limit: 2)) {
+      await withOperationTransform(ComposedTransform(base: currentOperationTransform)) {
+        await #expect(throws: SomeError.self) {
+          try await #run(FailingOperation(counter: counter))
+        }
+      }
+    }
+    expectNoDifference(counter.count, 3)
+  }
+}
+
+// MARK: - Helpers
+
+private struct SomeError: Equatable, Error {}
+
+private struct RetryingTransform: OperationTransform {
+  let limit: Int
+
+  func apply<Operation: OperationRequest>(
+    to operation: Operation
+  ) -> any OperationRequest<Operation.Value, Operation.Failure> {
+    operation.retry(limit: self.limit).backoff(.noBackoff).delayer(.noDelay)
+  }
+}
+
+/// A transform that adds nothing of its own, so that what reaches the operation is whatever the
+/// transform it was composed with contributes.
+private struct ComposedTransform: OperationTransform {
+  let base: (any OperationTransform)?
+
+  func apply<Operation: OperationRequest>(
+    to operation: Operation
+  ) -> any OperationRequest<Operation.Value, Operation.Failure> {
+    self.base?.apply(to: operation) ?? operation
+  }
+}
+
+private final class RunCounter: Sendable {
+  private let _count = RecursiveLock(0)
+
+  var count: Int {
+    self._count.withLock { $0 }
+  }
+
+  func increment() {
+    self._count.withLock { $0 += 1 }
+  }
+}
+
+private struct FailingOperation: OperationRequest, Sendable {
+  let counter: RunCounter
+
+  func run(
+    isolation: isolated (any Actor)?,
+    in context: OperationContext,
+    with continuation: OperationContinuation<Int, any Error>
+  ) async throws -> Int {
+    self.counter.increment()
+    throw SomeError()
+  }
+}
+
+private struct ConstantOperation<Value: Sendable>: OperationRequest, Sendable {
+  let value: Value
+
+  func run(
+    isolation: isolated (any Actor)?,
+    in context: OperationContext,
+    with continuation: OperationContinuation<Value, Never>
+  ) async throws(Never) -> Value {
+    self.value
+  }
+}
+
+private struct MaxRetriesOperation: OperationRequest, Sendable {
+  func run(
+    isolation: isolated (any Actor)?,
+    in context: OperationContext,
+    with continuation: OperationContinuation<Int, Never>
+  ) async throws(Never) -> Int {
+    context.operationMaxRetries
+  }
+}
+
+private struct YieldingOperation: OperationRequest, Sendable {
+  func run(
+    isolation: isolated (any Actor)?,
+    in context: OperationContext,
+    with continuation: OperationContinuation<Int, Never>
+  ) async throws(Never) -> Int {
+    continuation.yield(1)
+    return 2
+  }
+}


### PR DESCRIPTION
Replaces #24, which I've closed. Task-local instead of a new runtime type, based on `main` with no dependency on #23.

## Shape

```swift
struct SupervisionTransform: OperationTransform {
  func apply<Operation: OperationRequest>(
    to operation: Operation
  ) -> any OperationRequest<Operation.Value, Operation.Failure> {
    operation.retry(limit: 3).backoff(.exponential(.milliseconds(50)).jittered())
  }
}

try await withOperationTransform(SupervisionTransform()) {
  let mux = try await #run($launchMux(project))

  try await withOperationTransform(LoggingTransform()) {
    let endpoint = try await #run($bindEndpoint(mux.port))   // gets both
  }
}
```

`#run` is untouched at the call site. The hook is in `OperationRunner.run`, so manually constructed runners get it too. With nothing in scope the path is byte-identical to before.

The task local reaches child tasks, which a runtime object would not have done without being passed down — there's a test for that.

## Composition

Nesting a single transform composes rather than replaces. The alternative meant forgetting to thread the outer transform through **silently** dropped its behavior, and composing at all required every transform to carry a `base` property and every caller to remember to pass it.

Transforms are applied **innermost last**, so the one nearest the operation is the one declared in the innermost scope — the same order modifiers apply when written by hand.

Both scoping functions take a `behavior`, so either can add to what is in scope or replace it. The defaults differ because the common case does: nesting one more transform composes, and applying a sequence states exactly what runs.

## Public surface

Five symbols. The task local itself is private to the file:

- `protocol OperationTransform`
- `enum OperationTransformBehavior` — `.append` / `.override`
- `var operationTransforms: [any OperationTransform]` — read-only, outermost first
- `func withOperationTransform(_:behavior:isolation:operation:)` — defaults to `.append`
- `func withOperationTransforms(_:behavior:isolation:operation:)` — defaults to `.override`

The plural form covers carrying the current transforms across a boundary they do not cross on their own:

```swift
let transforms = operationTransforms
Task.detached {
  try await withOperationTransforms(transforms) { ... }
}
```

and, with an empty sequence, applying none of them at all.

## Erasure

No transforms in scope is a fully concrete path — `OperationRunner.run` returns before any of this.

For a single transform, the transform receives the operation as its **own concrete type**, so its modifiers dispatch into the operation statically rather than through a witness table, and no `AnyOperation` is involved. The one existential left is the return type of `apply(to:)`, which cannot be avoided while the protocol is generic over the operation it is applied to.

Only transforms above the innermost one fold through an `AnyOperation`, because an `any OperationRequest` does not open implicitly when passed back into `apply(to:)` — the return type is stated in terms of the opened operation's own `Value` and `Failure`, which the compiler will not map back.

Two tests pin this by having a modifier record the type name of the operand it wraps.

## Why a protocol rather than a closure

A closure cannot be generic over the operation it is applied to, and the result has to preserve that operation's `Value` and `Failure`. `OperationClient.StoreCreator` takes the same shape for the same reason.

## Transforms are applied once per run, in `run` rather than `init`

This is load-bearing. `_RetryModifier` carries a per-instance `RetryerID`. Applying a transform once to set up and again to run produces two different modifier instances, so the context ends up holding a retryer id matching no live modifier, and `retry` silently stops retrying. I verified this rather than assuming it: with the double application, `appliesTheTransformInScopeToARun` drops from 4 runs to 1, with no error raised anywhere.

The cost is that setting up the transformed operation reaches the underlying operation's `setup` a second time, on a context that already reflects it. Idempotent for every modifier in the tree, but it is a documented behavior change on `OperationRunner.run` rather than something invisible. Storing the transformed operation from `init` was the alternative, and it breaks `OperationRunner`'s conditional `Sendable`.

## Verification

502 tests in 39 suites pass, 25 known issues unchanged. Lint clean.

Mutation-checked each behavior: folding through `AnyOperation` from the start fails both erasure tests; dropping the `reversed()` flips composition order and fails both order tests; swapping `.append` and `.override` fails six; removing the setup call fails four.

Which `retry` wins between two composed transforms is deliberately not pinned by any test here — that is a separate discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)