### PR TITLE
Retry Condition Modifier

### DIFF
--- a/Examples/CanIClimb/CanIClimbKit/Sources/CanIClimbKit/MountainsCore/Mountain+Search.swift
+++ b/Examples/CanIClimb/CanIClimbKit/Sources/CanIClimbKit/MountainsCore/Mountain+Search.swift
@@ -101,7 +101,7 @@ extension Mountain {
         client.updateDetailQueries(mountains: searchResult.mountains)
         return searchResult
       } catch {
-        guard paging.pageId == self.initialPageId && context.isLastRunAttempt else { throw error }
+        guard paging.pageId == self.initialPageId && context.isKnownLastRunAttempt else { throw error }
         let mountains = try await catalog.localSearchMountains(by: self.search)
         let searchResult = Mountain.SearchResult(
           mountains: IdentifiedArray(uniqueElements: mountains),

--- a/Examples/CanIClimb/CanIClimbKit/Sources/CanIClimbKit/SharedHelpers/AlertStateOperation.swift
+++ b/Examples/CanIClimb/CanIClimbKit/Sources/CanIClimbKit/SharedHelpers/AlertStateOperation.swift
@@ -40,7 +40,7 @@ public struct _AlertStateModifier<Operation: OperationRequest>: OperationModifie
       }
       return value
     } catch {
-      if context.isLastRunAttempt, let failureAlert = self.failureAlert(error) {
+      if context.isKnownLastRunAttempt, let failureAlert = self.failureAlert(error) {
         await center.post(OperationAlertMessage(alert: failureAlert))
       }
       throw error

--- a/Examples/CanIClimb/CanIClimbKit/Tests/CanIClimbKitTests/MountainsCoreTests/Mountain+SearchTests.swift
+++ b/Examples/CanIClimb/CanIClimbKit/Tests/CanIClimbKitTests/MountainsCoreTests/Mountain+SearchTests.swift
@@ -68,7 +68,7 @@ extension DependenciesTestSuite {
           let handler = PaginatedEventHandler<Mountain.SearchQuery.State>(
             onPageResultReceived: { [mountain] _, result, context in
               guard
-                context.operationResultUpdateReason == .yieldedResult && context.isLastRunAttempt
+                context.operationResultUpdateReason == .yieldedResult && context.isKnownLastRunAttempt
               else { return }
               expectNoDifference(
                 try? result.get(),

--- a/Sources/OperationCore/Documentation.docc/OperationCore.md
+++ b/Sources/OperationCore/Documentation.docc/OperationCore.md
@@ -474,6 +474,10 @@ The library ships with a handful of package traits, which allow you to condition
 - ``OperationRequest/backoff(_:)``
 - ``OperationRequest/clock(_:)``
 - ``OperationRequest/retry(limit:)``
+- ``OperationRequest/retry(limit:when:)``
+- ``OperationRequest/retry(when:)``
+- ``OperationRequest/retry(_:)``
+- ``OperationRetryCondition``
 - ``OperationRequest/taskConfiguration(_:)-((OperationTaskConfiguration)->Void)``
 - ``OperationRequest/deduplicated()``
 - ``OperationRequest/modifier(_:)``

--- a/Sources/OperationCore/Modifiers/RetryOperation.swift
+++ b/Sources/OperationCore/Modifiers/RetryOperation.swift
@@ -26,28 +26,14 @@ public struct OperationRetryCondition: Sendable {
 
   private let predicate: @Sendable (any Error, OperationContext) async -> Bool
 
-  /// Creates an unbounded retry condition from a predicate you specify.
-  ///
-  /// An operation using the resulting condition is retried for as long as `predicate` returns true.
-  /// Combine it with ``maxRetries(_:)`` using ``&&(_:_:)`` in order to impose a bound.
-  ///
-  /// - Parameter predicate: A predicate that decides whether or not the thrown error warrants a
-  ///   retry.
-  public init(
-    _ predicate: @escaping @Sendable (any Error, OperationContext) async -> Bool
-  ) {
-    self.maxRetries = nil
-    self.predicate = predicate
-  }
-
   /// Creates a bounded retry condition from a predicate you specify.
   ///
   /// - Parameters:
   ///   - maxRetries: The maximum number of retry attempts for this predicate.
   ///   - predicate: A predicate that decides whether or not the thrown error warrants a retry.
   public init(
-    maxRetries: Int,
-    predicate: @escaping @Sendable (any Error, OperationContext) async -> Bool
+    maxRetries: Int? = nil,
+    _ predicate: @escaping @Sendable (any Error, OperationContext) async -> Bool
   ) {
     self.maxRetries = maxRetries
     self.predicate = predicate

--- a/Sources/OperationCore/Modifiers/RetryOperation.swift
+++ b/Sources/OperationCore/Modifiers/RetryOperation.swift
@@ -1,3 +1,153 @@
+// MARK: - OperationRetryCondition
+
+/// A condition that determines whether or not an operation is retried after it throws an error.
+///
+/// A retry condition pairs an optional upper bound on the number of retries, which is published to
+/// ``OperationContext/operationMaxRetries``, with a predicate that inspects the thrown error. Both
+/// must permit a retry in order for one to occur.
+///
+/// The bound is kept separate from the predicate rather than being folded into it because it must
+/// be known _before_ an attempt runs in order to power ``OperationContext/isKnownLastRunAttempt``.
+/// The predicate, in contrast, can only be evaluated _after_ an attempt has failed, as it requires
+/// the error.
+///
+/// Conditions are combined using ``&&(_:_:)`` and ``||(_:_:)``.
+///
+/// ```swift
+/// let condition = OperationRetryCondition.maxRetries(3)
+///   && OperationRetryCondition { error, _ in !(error is AuthenticationError) }
+/// ```
+public struct OperationRetryCondition: Sendable {
+  /// The upper bound this condition places on the number of retries, if it places one.
+  ///
+  /// A nil value indicates that this condition is unbounded, and permits retries for as long as its
+  /// predicate does.
+  public var maxRetries: Int?
+
+  private let predicate: @Sendable (any Error, OperationContext) async -> Bool
+
+  /// Creates an unbounded retry condition from a predicate you specify.
+  ///
+  /// An operation using the resulting condition is retried for as long as `predicate` returns true.
+  /// Combine it with ``maxRetries(_:)`` using ``&&(_:_:)`` in order to impose a bound.
+  ///
+  /// - Parameter predicate: A predicate that decides whether or not the thrown error warrants a
+  ///   retry.
+  public init(
+    _ predicate: @escaping @Sendable (any Error, OperationContext) async -> Bool
+  ) {
+    self.maxRetries = nil
+    self.predicate = predicate
+  }
+
+  /// Creates a bounded retry condition from a predicate you specify.
+  ///
+  /// - Parameters:
+  ///   - maxRetries: The maximum number of retry attempts for this predicate.
+  ///   - predicate: A predicate that decides whether or not the thrown error warrants a retry.
+  public init(
+    maxRetries: Int,
+    predicate: @escaping @Sendable (any Error, OperationContext) async -> Bool
+  ) {
+    self.maxRetries = maxRetries
+    self.predicate = predicate
+  }
+
+  /// Evaluates this condition with the specified `error` and `context`.
+  ///
+  /// A retry is permitted only when the retries performed so far are within ``maxRetries``, and
+  /// this condition's predicate permits one. The predicate is not evaluated when the bound has
+  /// already been reached.
+  ///
+  /// - Parameters:
+  ///   - error: The error thrown by an operation attempt.
+  ///   - context: The context from that operation attempt.
+  /// - Returns: Whether or not to perform another retry.
+  public func evaluate(error: some Error, in context: OperationContext) async -> Bool {
+    guard context.performedRetries < self.maxRetries ?? .max else { return false }
+    return await self.predicate(error, context)
+  }
+}
+
+// MARK: - Conditions
+
+extension OperationRetryCondition {
+  /// A condition that permits at most `limit` retries, regardless of the error thrown.
+  ///
+  /// - Parameter limit: The maximum number of retries.
+  /// - Returns: A retry condition.
+  public static func maxRetries(_ limit: Int) -> Self {
+    // NB: The bound is enforced by `evaluate(error:in:)` rather than by this predicate, so that
+    // `maxRetries` stays the single source of truth for it even when mutated at runtime.
+    Self(maxRetries: limit) { _, _ in true }
+  }
+
+  /// A condition that never permits a retry.
+  public static let never = Self(maxRetries: 0) { _, _ in false }
+}
+
+// MARK: - Combining
+
+extension OperationRetryCondition {
+  /// Combines 2 retry conditions such that both must permit a retry in order for one to occur.
+  ///
+  /// The resulting condition is bounded by the smaller of the 2 bounds, and its predicate is the
+  /// boolean AND of both predicates. `rhs`'s predicate is not evaluated when `lhs`'s predicate
+  /// returns false.
+  ///
+  /// - Parameters:
+  ///   - lhs: A retry condition.
+  ///   - rhs: A retry condition.
+  /// - Returns: A retry condition permitting a retry only when both `lhs` and `rhs` permit one.
+  public static func && (lhs: Self, rhs: Self) -> Self {
+    var condition = Self { error, context in
+      guard await lhs.predicate(error, context) else { return false }
+      return await rhs.predicate(error, context)
+    }
+    condition.maxRetries = lhs.combinedMaxRetries(with: rhs)
+    return condition
+  }
+
+  /// Combines 2 retry conditions such that either one permitting a retry is enough for one to
+  /// occur.
+  ///
+  /// The resulting condition is bounded by the larger of the 2 bounds, and is unbounded if either
+  /// operand is unbounded. `rhs`'s predicate is not evaluated when `lhs`'s predicate returns true.
+  ///
+  /// > Note: Since ``maxRetries(_:)`` carries a predicate that always permits a retry, using it as
+  /// > an operand here makes the combined predicate always permit one too. Impose bounds with
+  /// > ``&&(_:_:)`` on the outside instead.
+  ///
+  /// - Parameters:
+  ///   - lhs: A retry condition.
+  ///   - rhs: A retry condition.
+  /// - Returns: A retry condition permitting a retry when either `lhs` or `rhs` permits one.
+  public static func || (lhs: Self, rhs: Self) -> Self {
+    var condition = Self { error, context in
+      guard await lhs.predicate(error, context) else {
+        return await rhs.predicate(error, context)
+      }
+      return true
+    }
+    condition.maxRetries = lhs.unionMaxRetries(with: rhs)
+    return condition
+  }
+
+  private func combinedMaxRetries(with other: Self) -> Int? {
+    switch (self.maxRetries, other.maxRetries) {
+    case let (lhs?, rhs?): min(lhs, rhs)
+    case let (lhs?, nil): lhs
+    case let (nil, rhs?): rhs
+    case (nil, nil): nil
+    }
+  }
+
+  private func unionMaxRetries(with other: Self) -> Int? {
+    guard let lhs = self.maxRetries, let rhs = other.maxRetries else { return nil }
+    return max(lhs, rhs)
+  }
+}
+
 // MARK: - RetryModifier
 
 extension OperationRequest {
@@ -34,16 +184,97 @@ extension OperationRequest {
   ///   - limit: The maximum number of retries.
   /// - Returns: A ``ModifiedOperation``.
   public func retry(limit: Int) -> ModifiedOperation<Self, _RetryModifier<Self>> {
-    self.modifier(_RetryModifier(limit: limit))
+    self.retry(.maxRetries(limit))
+  }
+
+  /// Applies a retrying to this operation that is limited both by a maximum number of retries, and
+  /// by a predicate on the thrown error.
+  ///
+  /// A retry is performed when this operation throws an error, `predicate` returns true for that
+  /// error, and fewer than `limit` retries have been performed. `predicate` is evaluated _before_
+  /// any backoff is applied, so an error that does not warrant a retry fails the operation
+  /// immediately rather than after a delay.
+  ///
+  ///
+  /// ```swift
+  /// // Retries up to 3 times, but never burns a retry on an authentication failure.
+  /// let operation = $myOperation.retry(limit: 3) { error, _ in
+  ///   !(error is AuthenticationError)
+  /// }
+  /// ```
+  ///
+  /// See ``OperationRequest/retry(limit:)`` for details on backoff, cancellation, and the behavior
+  /// of applying multiple retry modifiers to a single operation.
+  ///
+  /// - Parameters:
+  ///   - limit: The maximum number of retries.
+  ///   - predicate: A predicate that decides whether or not the thrown error warrants a retry.
+  /// - Returns: A ``ModifiedOperation``.
+  public func retry(
+    limit: Int,
+    when predicate: @escaping @Sendable (Failure, OperationContext) async -> Bool
+  ) -> ModifiedOperation<Self, _RetryModifier<Self>> {
+    self.retry(.maxRetries(limit) && self.retryCondition(from: predicate))
+  }
+
+  /// Applies an unbounded retrying to this operation that is limited only by a predicate on the
+  /// thrown error.
+  ///
+  /// A retry is performed whenever this operation throws an error for which `predicate` returns
+  /// true. `predicate` is evaluated _before_ any backoff is applied, so an error that does not
+  /// warrant a retry fails the operation immediately rather than after a delay.
+  ///
+  /// > Important: This modifier places no upper bound on the number of retries. An operation that
+  /// > repeatedly throws errors for which `predicate` returns true will be retried indefinitely.
+  /// > Use ``OperationRequest/retry(limit:when:)`` if you want to impose a bound. Without one,
+  /// > ``OperationContext/operationMaxRetries`` reads as `Int.max` and
+  /// > ``OperationContext/isKnownLastRunAttempt`` is always false.
+  ///
+  /// See ``OperationRequest/retry(limit:)`` for details on backoff, cancellation, and the behavior
+  /// of applying multiple retry modifiers to a single operation.
+  ///
+  /// - Parameter predicate: A predicate that decides whether or not the thrown error warrants a
+  ///   retry.
+  /// - Returns: A ``ModifiedOperation``.
+  public func retry(
+    when predicate: @escaping @Sendable (Failure, OperationContext) async -> Bool
+  ) -> ModifiedOperation<Self, _RetryModifier<Self>> {
+    self.retry(self.retryCondition(from: predicate))
+  }
+
+  /// Applies a retrying to this operation using an ``OperationRetryCondition``.
+  ///
+  /// See ``OperationRequest/retry(limit:)`` for details on backoff, cancellation, and the behavior
+  /// of applying multiple retry modifiers to a single operation.
+  ///
+  /// - Parameter condition: The condition under which this operation is retried.
+  /// - Returns: A ``ModifiedOperation``.
+  public func retry(
+    _ condition: OperationRetryCondition
+  ) -> ModifiedOperation<Self, _RetryModifier<Self>> {
+    self.modifier(_RetryModifier(condition: condition))
+  }
+
+  private func retryCondition(
+    from predicate: @escaping @Sendable (Failure, OperationContext) async -> Bool
+  ) -> OperationRetryCondition {
+    OperationRetryCondition { error, context in
+      guard let error = error as? Failure else { return true }
+      return await predicate(error, context)
+    }
   }
 }
 
 public struct _RetryModifier<Operation: OperationRequest>: OperationModifier, Sendable {
-  let limit: Int
+  let condition: OperationRetryCondition
   private let retryerId = RetryerID()
 
+  init(condition: OperationRetryCondition) {
+    self.condition = condition
+  }
+
   public func setup(context: inout OperationContext, using operation: Operation) {
-    context.operationMaxRetries = self.limit
+    context.operationRetryCondition = self.condition
     context[RetryerIDKey.self] = self.retryerId
     operation.setup(context: &context)
   }
@@ -59,17 +290,25 @@ public struct _RetryModifier<Operation: OperationRequest>: OperationModifier, Se
     }
 
     var context = context
-    for index in 0..<context.operationMaxRetries {
+    var retryIndex: Int?
+    while true {
+      context.operationRetryIndex = retryIndex
       do {
-        context.operationRetryIndex = index == 0 ? nil : index - 1
         return try await operation.run(isolation: isolation, in: context, with: continuation)
       } catch {
-        try? await context.operationDelayer.delay(for: context.operationBackoffFunction(index + 1))
+        // NB: A cancelled task would otherwise burn through every remaining attempt back to back,
+        // since the delay below cannot suspend once cancelled.
+        guard !Task.isCancelled else { throw error }
+
+        guard await context.operationRetryCondition.evaluate(error: error, in: context) else {
+          throw error
+        }
+        let performedRetries = context.performedRetries
+        try? await context.operationDelayer
+          .delay(for: context.operationBackoffFunction(performedRetries + 1))
+        retryIndex = performedRetries
       }
     }
-    context.operationRetryIndex =
-      context.operationMaxRetries > 0 ? context.operationMaxRetries - 1 : nil
-    return try await operation.run(isolation: isolation, in: context, with: continuation)
   }
 }
 
@@ -98,21 +337,46 @@ extension OperationContext {
     static let defaultValue: Int? = nil
   }
 
+  /// The number of retries that have been performed for the current operation run.
+  var performedRetries: Int {
+    self.operationRetryIndex.map { $0 + 1 } ?? 0
+  }
+
+  /// The ``OperationRetryCondition`` for an operation run.
+  ///
+  /// The default value of this context property permits no retries. Applying any of the
+  /// `retry` modifiers will set this value to the condition that modifier was built from.
+  public var operationRetryCondition: OperationRetryCondition {
+    get { self[RetryConditionKey.self] }
+    set { self[RetryConditionKey.self] = newValue }
+  }
+
+  private enum RetryConditionKey: Key {
+    static var defaultValue: OperationRetryCondition { .maxRetries(0) }
+  }
+
   /// The maximum number of retries for an operation run.
   ///
-  /// The default value of this context property is 0. However, using
-  /// ``OperationRequest/retry(limit:)`` will set this value to the `limit` parameter.
+  /// This value is the upper bound imposed by ``operationRetryCondition``, and defaults to 0. Using
+  /// ``OperationRequest/retry(limit:)`` sets it to the `limit` parameter. A condition need not
+  /// impose a bound at all, such as the one created by ``OperationRequest/retry(when:)``, in which
+  /// case this property reads as `Int.max`.
   public var operationMaxRetries: Int {
-    get { self[MaxRetriesKey.self] }
-    set { self[MaxRetriesKey.self] = newValue }
+    get { self.operationRetryCondition.maxRetries ?? .max }
+    set { self.operationRetryCondition.maxRetries = newValue }
   }
 
-  private enum MaxRetriesKey: Key {
-    static let defaultValue = 0
-  }
-
-  /// Whether or not the operation run is on its last retry attempt.
+  @available(*, deprecated, renamed: "isKnownLastRetryAttempt")
   public var isLastRetryAttempt: Bool {
+    self.isKnownLastRetryAttempt
+  }
+
+  /// Whether or not the operation run is known to be on its last retry attempt.
+  ///
+  /// This value is only ever true when ``operationRetryCondition`` imposes an upper bound on the
+  /// number of retries. When it does not, the run's last retry attempt cannot be identified in
+  /// advance, and this value is always false.
+  public var isKnownLastRetryAttempt: Bool {
     self.operationRetryIndex == self.operationMaxRetries - 1
   }
 
@@ -130,15 +394,24 @@ extension OperationContext {
     self.operationRetryIndex == nil
   }
 
-  /// Whether or not the operation run is on its final attempt.
+  @available(*, deprecated, renamed: "isKnownLastRunAttempt")
+  public var isLastRunAttempt: Bool {
+    self.isKnownLastRunAttempt
+  }
+
+  /// Whether or not the operation run is known to be on its final attempt.
   ///
   /// When this value is true, the operation run will no longer be retried if it throws an error.
+  /// The converse does not hold. A false value means only that the final attempt cannot be
+  /// identified from the retry count alone, which is the case when ``operationRetryCondition``
+  /// imposes no upper bound, or when its predicate declines a retry for an error that has not been
+  /// thrown yet.
   ///
-  /// You can check this property as an indicator of when you should try to fetch data with a
-  /// minimal chance of an error being thrown. For instance, you could fetch data stored locally on
-  /// disk rather than from your server, as loading from disk isn't as error prone as fetching data
-  /// from over the network, in order to implement offline support.
-  public var isLastRunAttempt: Bool {
-    (self.isFirstRunAttempt && self.operationMaxRetries == 0) || self.isLastRetryAttempt
+  /// You can check this property from within a `catch` block as an indicator of when you should try
+  /// to recover from an error with a minimal chance of another error being thrown. For instance,
+  /// you could load data stored locally on disk rather than fetching it from your server in order
+  /// to implement offline support.
+  public var isKnownLastRunAttempt: Bool {
+    (self.isFirstRunAttempt && self.operationMaxRetries == 0) || self.isKnownLastRetryAttempt
   }
 }

--- a/Sources/OperationCore/NetworkObserving/CompletelyOfflineOperation.swift
+++ b/Sources/OperationCore/NetworkObserving/CompletelyOfflineOperation.swift
@@ -13,7 +13,8 @@ extension OperationRequest {
   ///
   /// Attaching this modifier to your operation guarantees.
   /// - That ``OperationContext/satisfiedConnectionStatus`` is set to ``NetworkConnectionStatus/disconnected``.
-  /// - That ``OperationContext/operationMaxRetries`` is set to 0.
+  /// - That ``OperationContext/operationRetryCondition`` permits no retries, and that
+  ///   ``OperationContext/operationMaxRetries`` is therefore set to 0.
   /// - That ``OperationContext/operationBackoffFunction`` is set to ``OperationBackoffFunction/noBackoff``.
   ///
   /// - Parameter isOffline: Whether the query is completely offline. Defaults to `true`. If

--- a/Tests/OperationTests/ModifiersTests/RetryOperationTests.swift
+++ b/Tests/OperationTests/ModifiersTests/RetryOperationTests.swift
@@ -192,6 +192,308 @@ struct RetryOperationTests {
     let indicies = await query.retryIndicies
     expectNoDifference(indicies, [nil, 0, 1, 2, 3, 4])
   }
+
+  @Test("Predicate Returning False Stops Retrying Before The Limit Is Reached")
+  func predicateReturningFalseStopsRetryingBeforeTheLimitIsReached() async {
+    let query = CountingQuery()
+    await query.ensureFails()
+    let store = OperationStore.detached(
+      query: query.backoff(.noBackoff)
+        .delayer(.noDelay)
+        .retry(limit: 5) { _, context in (context.operationRetryIndex ?? -1) < 1 },
+      initialValue: nil
+    )
+    _ = try? await store.fetch()
+    let count = await query.fetchCount
+    expectNoDifference(count, 3)
+  }
+
+  @Test("Does Not Delay When The Predicate Declines A Retry")
+  func doesNotDelayWhenThePredicateDeclinesARetry() async {
+    let delayer = TestDelayer()
+    let query = FailingQuery()
+      .delayer(delayer)
+      .backoff(.linear(.milliseconds(1000)))
+      .retry(limit: 5) { _, _ in false }
+    let store = OperationStore.detached(query: query, initialValue: nil)
+    _ = try? await store.fetch()
+    expectNoDifference(
+      delayer.delays,
+      [],
+      "The backoff should not be awaited for an error that does not warrant a retry."
+    )
+  }
+
+  @Test("Passes The Thrown Error To The Predicate")
+  func passesTheThrownErrorToThePredicate() async {
+    let errors = ErrorRecorder()
+    let query = FailingQuery()
+      .backoff(.noBackoff)
+      .delayer(.noDelay)
+      .retry(limit: 2) { error, _ in
+        await errors.record(error)
+        return true
+      }
+    let store = OperationStore.detached(query: query, initialValue: nil)
+    _ = try? await store.fetch()
+    let recorded = await errors.errors
+    expectNoDifference(recorded.count, 2)
+    expectNoDifference(recorded.allSatisfy { $0 is FailingQuery.SomeError }, true)
+  }
+
+  @Test("Awaits The Predicate Once Per Failed Attempt That Is Not The Last")
+  func awaitsThePredicateOncePerFailedAttemptThatIsNotTheLast() async {
+    let counter = Counter()
+    let query = FailingQuery()
+      .backoff(.noBackoff)
+      .delayer(.noDelay)
+      .retry(limit: 3) { _, _ in
+        await counter.increment()
+        return true
+      }
+    let store = OperationStore.detached(query: query, initialValue: nil)
+    _ = try? await store.fetch()
+    let count = await counter.count
+    expectNoDifference(
+      count,
+      3,
+      "The predicate should not be evaluated on the final attempt, since the limit already rules out a retry."
+    )
+  }
+
+  @Test("Bare Predicate Modifier Retries Without An Upper Bound")
+  func barePredicateModifierRetriesWithoutAnUpperBound() async {
+    let query = CountingQuery()
+    await query.ensureFails()
+    let store = OperationStore.detached(
+      query: query.backoff(.noBackoff)
+        .delayer(.noDelay)
+        .retry(when: { _, context in (context.operationRetryIndex ?? -1) < 8 }),
+      initialValue: nil
+    )
+    expectNoDifference(store.context.operationMaxRetries, Int.max)
+    _ = try? await store.fetch()
+    let count = await query.fetchCount
+    expectNoDifference(count, 10)
+  }
+
+  @Test("Is Not A Known Last Run Attempt When The Retry Condition Is Unbounded")
+  func isNotAKnownLastRunAttemptWhenTheRetryConditionIsUnbounded() async {
+    let query = LastRunAttemptReadingQuery()
+    let store = OperationStore.detached(
+      query: query.backoff(.noBackoff)
+        .delayer(.noDelay)
+        .retry(when: { _, context in (context.operationRetryIndex ?? -1) < 2 }),
+      initialValue: nil
+    )
+    _ = try? await store.fetch()
+    let flags = await query.flags
+    expectNoDifference(flags, [false, false, false, false])
+  }
+
+  @Test("Is A Known Last Run Attempt On The Final Attempt Of A Bounded Condition")
+  func isAKnownLastRunAttemptOnTheFinalAttemptOfABoundedCondition() async {
+    let query = LastRunAttemptReadingQuery()
+    let store = OperationStore.detached(
+      query: query.backoff(.noBackoff).delayer(.noDelay).retry(limit: 3),
+      initialValue: nil
+    )
+    _ = try? await store.fetch()
+    let flags = await query.flags
+    expectNoDifference(flags, [false, false, false, true])
+  }
+
+  @Test("Combining Conditions Uses The Smaller Retry Bound")
+  func combiningConditionsUsesTheSmallerRetryBound() async {
+    let query = CountingQuery()
+    await query.ensureFails()
+    let store = OperationStore.detached(
+      query: query.backoff(.noBackoff)
+        .delayer(.noDelay)
+        .retry(.maxRetries(10) && .maxRetries(3)),
+      initialValue: nil
+    )
+    expectNoDifference(store.context.operationMaxRetries, 3)
+    _ = try? await store.fetch()
+    let count = await query.fetchCount
+    expectNoDifference(count, 4)
+  }
+
+  @Test("Combining An Unbounded Condition With A Bounded One Keeps The Bound")
+  func combiningAnUnboundedConditionWithABoundedOneKeepsTheBound() async {
+    let query = FailingQuery()
+      .backoff(.noBackoff)
+      .delayer(.noDelay)
+      .retry(.maxRetries(4) && OperationRetryCondition { _, _ in true })
+    let store = OperationStore.detached(query: query, initialValue: nil)
+    expectNoDifference(store.context.operationMaxRetries, 4)
+  }
+
+  @Test("Never Condition Does Not Perform Any Retries")
+  func neverConditionDoesNotPerformAnyRetries() async {
+    let query = CountingQuery()
+    await query.ensureFails()
+    let store = OperationStore.detached(
+      query: query.backoff(.noBackoff).delayer(.noDelay).retry(.never),
+      initialValue: nil
+    )
+    _ = try? await store.fetch()
+    let count = await query.fetchCount
+    expectNoDifference(count, 1)
+  }
+
+  @Test("Stops Retrying When The Underlying Task Is Cancelled")
+  func stopsRetryingWhenTheUnderlyingTaskIsCancelled() async {
+    let query = CountingQuery()
+    await query.ensureFails()
+    let store = OperationStore.detached(
+      query: query.backoff(.noBackoff).delayer(.noDelay).retry(limit: 5),
+      initialValue: nil
+    )
+    let task = store.fetchTask()
+    task.cancel()
+    _ = try? await task.runIfNeeded()
+    let count = await query.fetchCount
+    expectNoDifference(
+      count,
+      1,
+      "A cancelled task should not burn through every remaining retry attempt."
+    )
+  }
+
+  @Test("Combining Conditions With Or Uses The Larger Retry Bound")
+  func combiningConditionsWithOrUsesTheLargerRetryBound() async {
+    let query = CountingQuery()
+    await query.ensureFails()
+    let store = OperationStore.detached(
+      query: query.backoff(.noBackoff)
+        .delayer(.noDelay)
+        .retry(.maxRetries(2) || .maxRetries(5)),
+      initialValue: nil
+    )
+    expectNoDifference(store.context.operationRetryCondition.maxRetries, 5)
+    _ = try? await store.fetch()
+    let count = await query.fetchCount
+    expectNoDifference(count, 6)
+  }
+
+  @Test("Or Combines The Predicates Of Both Operands")
+  func orCombinesThePredicatesOfBothOperands() async {
+    let query = CountingQuery()
+    await query.ensureFails()
+    let store = OperationStore.detached(
+      query: query.backoff(.noBackoff)
+        .delayer(.noDelay)
+        .retry(
+          .maxRetries(5)
+            && (OperationRetryCondition { _, context in (context.operationRetryIndex ?? -1) < 0 }
+              || OperationRetryCondition { _, context in (context.operationRetryIndex ?? -1) < 2 })
+        ),
+      initialValue: nil
+    )
+    _ = try? await store.fetch()
+    let count = await query.fetchCount
+    expectNoDifference(
+      count,
+      4,
+      "Retries should continue for as long as either predicate permits one, up to the bound."
+    )
+  }
+
+  @Test("Or Does Not Evaluate The Right Hand Predicate When The Left One Permits A Retry")
+  func orDoesNotEvaluateTheRightHandPredicateWhenTheLeftOnePermitsARetry() async {
+    let counter = Counter()
+    let query = FailingQuery()
+      .backoff(.noBackoff)
+      .delayer(.noDelay)
+      .retry(
+        .maxRetries(3)
+          && (OperationRetryCondition { _, _ in true }
+            || OperationRetryCondition { _, _ in
+              await counter.increment()
+              return true
+            })
+      )
+    let store = OperationStore.detached(query: query, initialValue: nil)
+    _ = try? await store.fetch()
+    let count = await counter.count
+    expectNoDifference(count, 0)
+  }
+
+  @Test("Or With A Max Retries Operand Always Permits A Retry")
+  func orWithAMaxRetriesOperandAlwaysPermitsARetry() async {
+    let query = CountingQuery()
+    await query.ensureFails()
+    let store = OperationStore.detached(
+      query: query.backoff(.noBackoff)
+        .delayer(.noDelay)
+        .retry(.maxRetries(3) && (.maxRetries(1) || OperationRetryCondition { _, _ in false })),
+      initialValue: nil
+    )
+    _ = try? await store.fetch()
+    let count = await query.fetchCount
+    expectNoDifference(
+      count,
+      4,
+      "`maxRetries` carries an always-true predicate, so using it as an `||` operand makes the combined predicate always permit a retry, leaving only the outer bound of 3 to stop it."
+    )
+  }
+
+  @Test("Or With Never Falls Back To The Other Operand")
+  func orWithNeverFallsBackToTheOtherOperand() async {
+    let query = CountingQuery()
+    await query.ensureFails()
+    let store = OperationStore.detached(
+      query: query.backoff(.noBackoff)
+        .delayer(.noDelay)
+        .retry(.never || .maxRetries(3)),
+      initialValue: nil
+    )
+    expectNoDifference(store.context.operationRetryCondition.maxRetries, 3)
+    _ = try? await store.fetch()
+    let count = await query.fetchCount
+    expectNoDifference(count, 4)
+  }
+
+  @Test("Exposes The Retry Bound Of A Condition")
+  func exposesTheRetryBoundOfACondition() {
+    expectNoDifference(OperationRetryCondition.maxRetries(4).maxRetries, 4)
+    expectNoDifference(OperationRetryCondition.never.maxRetries, 0)
+    expectNoDifference(OperationRetryCondition { _, _ in true }.maxRetries, nil)
+    expectNoDifference((OperationRetryCondition.maxRetries(4) && .maxRetries(9)).maxRetries, 4)
+    expectNoDifference((OperationRetryCondition.maxRetries(4) || .maxRetries(9)).maxRetries, 9)
+  }
+}
+
+private actor Counter {
+  private(set) var count = 0
+
+  func increment() {
+    self.count += 1
+  }
+}
+
+private actor ErrorRecorder {
+  private(set) var errors = [any Error]()
+
+  func record(_ error: any Error) {
+    self.errors.append(error)
+  }
+}
+
+private actor LastRunAttemptReadingQuery: QueryRequest, Identifiable {
+  private(set) var flags = [Bool]()
+
+  func fetch(
+    isolation: isolated (any Actor)?,
+    in context: OperationContext,
+    with continuation: OperationContinuation<Int, any Error>
+  ) async throws -> Int {
+    await isolate(self) { @Sendable in $0.flags.append(context.isKnownLastRunAttempt) }
+    throw SomeError()
+  }
+
+  private struct SomeError: Error {}
 }
 
 private actor RetryIndexReadingQuery: QueryRequest, Identifiable {


### PR DESCRIPTION
Beefs up the retry modifier to work on predicates directly through a new `OperationRetryCondition`. This makes conditional retries more flexible, and not solely limited to just a limit.

`isLastRunAttempt` on the context also is deprecated and renamed to `isKnownLastRunAttempt` since we can't assume whether or not its the final attempt based on the retry index anymore due to the addition of the predicate. When the new value is `true`, it is guaranteed to be the last run attempt. However, `false` no longer guarantees the last run attempt anymore.

Existing behavior should be unaffected, since this is an additive change. `isKnownLastRunAttempt` will continue to work like today's `isLastRunAttempt` as long as no predicates are involved in the underlying retry condition.