### PR TITLE
Operation Setup Scope

### DIFF
--- a/Sources/OperationCore/ModifierSetupScope.swift
+++ b/Sources/OperationCore/ModifierSetupScope.swift
@@ -39,6 +39,9 @@ extension OperationContext {
     /// This pass stops at the operation itself, which was already set up during
     /// ``runtimeInitialSetup``. A transform's configuration therefore lands on top of the
     /// operation's own, and wins.
+    ///
+    /// The context keeps this value for the duration of that run, so an operation can also read it
+    /// to tell whether transforms are in scope.
     case operationRun
   }
 }

--- a/Sources/OperationCore/ModifierSetupScope.swift
+++ b/Sources/OperationCore/ModifierSetupScope.swift
@@ -1,0 +1,44 @@
+// MARK: - ModifierSetupScope
+
+extension OperationContext {
+  /// The setup pass that a modifier is currently being set up in.
+  ///
+  /// Most modifiers can ignore this. It matters when a modifier claims something that belongs to
+  /// the operation for its entire lifetime, rather than to a single run.
+  ///
+  /// ```swift
+  /// public func setup(context: inout OperationContext, using operation: Operation) {
+  ///   // A transform is set up on every run, so claiming this each time would hand the
+  ///   // connection to whichever run set up last.
+  ///   if context.modifierSetupScope == .runtimeInitialSetup {
+  ///     context.connectionPool = ConnectionPool()
+  ///   }
+  ///   operation.setup(context: &context)
+  /// }
+  /// ```
+  public var modifierSetupScope: ModifierSetupScope {
+    get { self[ModifierSetupScopeKey.self] }
+    set { self[ModifierSetupScopeKey.self] = newValue }
+  }
+
+  private enum ModifierSetupScopeKey: Key {
+    static var defaultValue: ModifierSetupScope { .runtimeInitialSetup }
+  }
+
+  /// A pass in which an ``OperationModifier`` is set up.
+  public enum ModifierSetupScope: Hashable, Sendable {
+    /// An ``OperationRunner``'s one-time setup of the operation it was created with.
+    ///
+    /// Modifiers write their configuration before setting up the operation they're attached to,
+    /// so the ones applied closest to the operation win. This is why an operation's own
+    /// ``OperationRequest/retry(limit:)`` beats the one `OperationClient` applies by default.
+    case runtimeInitialSetup
+
+    /// The setup of the modifiers that the ``OperationTransform``s in scope apply to a single run.
+    ///
+    /// This pass stops at the operation itself, which was already set up during
+    /// ``runtimeInitialSetup``. A transform's configuration therefore lands on top of the
+    /// operation's own, and wins.
+    case operationRun
+  }
+}

--- a/Sources/OperationCore/Modifiers/RetryOperation.swift
+++ b/Sources/OperationCore/Modifiers/RetryOperation.swift
@@ -166,6 +166,22 @@ extension OperationRequest {
   ///   .retry(limit: 3)
   /// ```
   ///
+  /// A retry modifier applied by an ``OperationTransform`` in scope for a run is the exception to
+  /// that rule, which lets you dial an operation's persistence up or down for a particular piece of
+  /// work. The transform states the limit, and its predicate is OR'd with the operation's own.
+  ///
+  /// ```swift
+  /// let library = client.store(for: $syncLibrary)
+  ///
+  /// // Retries twice. Someone is watching a spinner, so give up quickly.
+  /// try await library.fetch()
+  ///
+  /// try await withOperationTransform(BackgroundSyncTransform(limit: 20)) {
+  ///   // Retries 20 times. Nobody is waiting, so be as persistent as it takes.
+  ///   try await library.fetch()
+  /// }
+  /// ```
+  ///
   /// - Parameters:
   ///   - limit: The maximum number of retries.
   /// - Returns: A ``ModifiedOperation``.
@@ -260,8 +276,24 @@ public struct _RetryModifier<Operation: OperationRequest>: OperationModifier, Se
   }
 
   public func setup(context: inout OperationContext, using operation: Operation) {
-    context.operationRetryCondition = self.condition
-    context[RetryerIDKey.self] = self.retryerId
+    switch context.modifierSetupScope {
+    case .runtimeInitialSetup:
+      context.operationRetryCondition = self.condition
+      context[RetryerIDKey.self] = self.retryerId
+    case .operationRun:
+      // NB: The transform is the most local description of how this run should behave, so it states
+      // the limit outright. Its predicate only widens the operation's own, as a transform raising
+      // the limit shouldn't also start retrying errors the operation declared unretryable.
+      var condition = self.condition || context.operationRetryCondition
+      condition.maxRetries = self.condition.maxRetries
+      context.operationRetryCondition = condition
+
+      // NB: A transform's retryer sits outside the operation's own modifiers, so taking the loop
+      // from a retryer the operation already has would relocate it outside of modifiers such as
+      // `deduplicated()`, making every retry re-enter them. Steer the existing loop through the
+      // condition instead, and only claim the loop when there is none to steer.
+      if context[RetryerIDKey.self] == nil { context[RetryerIDKey.self] = self.retryerId }
+    }
     operation.setup(context: &context)
   }
 
@@ -332,6 +364,10 @@ extension OperationContext {
   ///
   /// The default value of this context property permits no retries. Applying any of the
   /// `retry` modifiers will set this value to the condition that modifier was built from.
+  ///
+  /// The retry loop reads this property on each attempt, and is always the innermost one in the
+  /// operation. A retry modifier applied by an ``OperationTransform`` steers that loop rather than
+  /// adding one of its own.
   public var operationRetryCondition: OperationRetryCondition {
     get { self[RetryConditionKey.self] }
     set { self[RetryConditionKey.self] = newValue }

--- a/Sources/OperationCore/Modifiers/RetryOperation.swift
+++ b/Sources/OperationCore/Modifiers/RetryOperation.swift
@@ -63,8 +63,6 @@ extension OperationRetryCondition {
   /// - Parameter limit: The maximum number of retries.
   /// - Returns: A retry condition.
   public static func maxRetries(_ limit: Int) -> Self {
-    // NB: The bound is enforced by `evaluate(error:in:)` rather than by this predicate, so that
-    // `maxRetries` stays the single source of truth for it even when mutated at runtime.
     Self(maxRetries: limit) { _, _ in true }
   }
 
@@ -171,14 +169,24 @@ extension OperationRequest {
   /// work. The transform states the limit, and its predicate is OR'd with the operation's own.
   ///
   /// ```swift
-  /// let library = client.store(for: $syncLibrary)
+  /// struct BackgroundSyncTransform: OperationTransform {
+  ///   let limit: Int
   ///
-  /// // Retries twice. Someone is watching a spinner, so give up quickly.
-  /// try await library.fetch()
+  ///   func apply<Operation: OperationRequest>(
+  ///     to operation: Operation
+  ///   ) -> any OperationRequest<Operation.Value, Operation.Failure> {
+  ///     operation.retry(limit: self.limit)
+  ///   }
+  /// }
+  ///
+  /// let store = client.store(for: $syncLibrary)
+  ///
+  /// // Uses default retry limit applied by the client.
+  /// try await store.fetch()
   ///
   /// try await withOperationTransform(BackgroundSyncTransform(limit: 20)) {
-  ///   // Retries 20 times. Nobody is waiting, so be as persistent as it takes.
-  ///   try await library.fetch()
+  ///   // Uses 20 for the retry limit
+  ///   try await store.fetch()
   /// }
   /// ```
   ///
@@ -281,18 +289,13 @@ public struct _RetryModifier<Operation: OperationRequest>: OperationModifier, Se
       context.operationRetryCondition = self.condition
       context[RetryerIDKey.self] = self.retryerId
     case .operationRun:
-      // NB: The transform is the most local description of how this run should behave, so it states
-      // the limit outright. Its predicate only widens the operation's own, as a transform raising
-      // the limit shouldn't also start retrying errors the operation declared unretryable.
       var condition = self.condition || context.operationRetryCondition
       condition.maxRetries = self.condition.maxRetries
       context.operationRetryCondition = condition
 
-      // NB: A transform's retryer sits outside the operation's own modifiers, so taking the loop
-      // from a retryer the operation already has would relocate it outside of modifiers such as
-      // `deduplicated()`, making every retry re-enter them. Steer the existing loop through the
-      // condition instead, and only claim the loop when there is none to steer.
-      if context[RetryerIDKey.self] == nil { context[RetryerIDKey.self] = self.retryerId }
+      if context[RetryerIDKey.self] == nil {
+        context[RetryerIDKey.self] = self.retryerId
+      }
     }
     operation.setup(context: &context)
   }
@@ -355,7 +358,6 @@ extension OperationContext {
     static let defaultValue: Int? = nil
   }
 
-  /// The number of retries that have been performed for the current operation run.
   var performedRetries: Int {
     self.operationRetryIndex.map { $0 + 1 } ?? 0
   }

--- a/Sources/OperationCore/OperationRunner.swift
+++ b/Sources/OperationCore/OperationRunner.swift
@@ -74,7 +74,6 @@ public struct OperationRunner<Operation: OperationRequest> {
     var runContext = context
     runContext.modifierSetupScope = .operationRun
     transformed.setup(context: &runContext)
-    runContext.modifierSetupScope = .runtimeInitialSetup
     return try await transformed.run(isolation: isolation, in: runContext, with: continuation)
   }
 }

--- a/Sources/OperationCore/OperationRunner.swift
+++ b/Sources/OperationCore/OperationRunner.swift
@@ -45,9 +45,12 @@ public struct OperationRunner<Operation: OperationRequest> {
   /// Runs the underlying operation of this runner.
   ///
   /// Any ``OperationTransform``s in scope for the current task have their modifiers applied to
-  /// the operation for this run, and ``OperationRequest/setup(context:)-8y79v`` is invoked on the
-  /// result. Setup therefore reaches the underlying operation a second time in that case, on a
-  /// context that already reflects it.
+  /// the operation for this run, and ``OperationRequest/setup(context:)-8y79v`` is invoked on
+  /// those modifiers with ``OperationContext/modifierSetupScope`` set to
+  /// ``OperationContext/ModifierSetupScope/operationRun``. That pass stops at the underlying
+  /// operation, which is only ever set up once, in ``init(operation:initialContext:)``. A
+  /// transform's configuration is therefore written on top of the operation's own, and takes
+  /// precedence over it.
   ///
   /// - Parameters:
   ///   - isolation: The current actor-isolation of this operation run.
@@ -67,9 +70,11 @@ public struct OperationRunner<Operation: OperationRequest> {
     guard !transforms.isEmpty else {
       return try await self.operation.run(isolation: isolation, in: context, with: continuation)
     }
-    let transformed = transforms.applied(to: self.operation)
+    let transformed = self.operation.applying(transforms)
     var runContext = context
+    runContext.modifierSetupScope = .operationRun
     transformed.setup(context: &runContext)
+    runContext.modifierSetupScope = .runtimeInitialSetup
     return try await transformed.run(isolation: isolation, in: runContext, with: continuation)
   }
 }

--- a/Sources/OperationCore/OperationTransform.swift
+++ b/Sources/OperationCore/OperationTransform.swift
@@ -57,8 +57,6 @@ extension OperationRequest {
   ) -> any OperationRequest<Value, Failure> {
     guard let innermost = transforms.last else { return self }
 
-    // NB: The boundary stops a scoped setup pass from descending into this operation, which the
-    // runtime has already set up. See `_OperationChainBoundary` for why that matters.
     let applied = innermost.apply(to: self.modifier(_OperationChainBoundary()))
     guard transforms.count > 1 else { return applied }
     return transforms.dropLast()
@@ -71,14 +69,8 @@ extension OperationRequest {
 
 // MARK: - OperationChainBoundary
 
-/// A modifier marking the point where an operation's own modifiers begin, and the modifiers
-/// applied to it by the ``OperationTransform``s in scope end.
 struct _OperationChainBoundary<Operation: OperationRequest>: OperationModifier, Sendable {
   func setup(context: inout OperationContext, using operation: Operation) {
-    // NB: An `OperationRunner` sets its operation up a single time, so setting it up again on
-    // every run would mint a second deduplication storage, re-append its operation controllers,
-    // and re-add its stale-when-revalidate predicates. Descending would also overwrite the
-    // configuration that the transforms in scope just wrote on the way back down the chain.
     guard context.modifierSetupScope != .operationRun else { return }
     operation.setup(context: &context)
   }

--- a/Sources/OperationCore/OperationTransform.swift
+++ b/Sources/OperationCore/OperationTransform.swift
@@ -18,6 +18,27 @@
 ///   let endpoint = try await #run($bindEndpoint(mux.port))
 /// }
 /// ```
+///
+/// A transform is applied at the point of a run, which makes it the most local description of how
+/// that run should behave. Its modifiers therefore win over the ones the operation was built with,
+/// including the defaults an `OperationClient` applies to every store it creates.
+///
+/// ```swift
+/// let library = client.store(for: $syncLibrary)
+///
+/// // Retries twice with the client's backoff.
+/// try await library.fetch()
+///
+/// try await withOperationTransform(BackgroundSyncTransform(limit: 20)) {
+///   // Retries 20 times with the transform's backoff. Same store, same operation.
+///   try await library.fetch()
+/// }
+/// ```
+///
+/// > Note: A transform's modifiers are set up once per run, rather than once per operation, so a
+/// > modifier that allocates state during setup gets fresh state every time. Applying
+/// > ``OperationRequest/deduplicated()`` from a transform deduplicates nothing, as each run builds
+/// > its own storage. Apply stateful modifiers when building the operation instead.
 public protocol OperationTransform: Sendable {
   /// Applies this transform's modifiers to an operation.
   ///
@@ -30,18 +51,45 @@ public protocol OperationTransform: Sendable {
 
 // MARK: - Applying
 
-extension [any OperationTransform] {
-  func applied<Operation: OperationRequest>(
-    to operation: Operation
-  ) -> any OperationRequest<Operation.Value, Operation.Failure> {
-    guard let innermost = self.last else { return operation }
-    let applied = innermost.apply(to: operation)
-    guard self.count > 1 else { return applied }
-    return self.dropLast()
+extension OperationRequest {
+  func applying(
+    _ transforms: [any OperationTransform]
+  ) -> any OperationRequest<Value, Failure> {
+    guard let innermost = transforms.last else { return self }
+
+    // NB: The boundary stops a scoped setup pass from descending into this operation, which the
+    // runtime has already set up. See `_OperationChainBoundary` for why that matters.
+    let applied = innermost.apply(to: self.modifier(_OperationChainBoundary()))
+    guard transforms.count > 1 else { return applied }
+    return transforms.dropLast()
       .reversed()
       .reduce(AnyOperation(applied)) { transformed, transform in
         AnyOperation(transform.apply(to: transformed))
       }
+  }
+}
+
+// MARK: - OperationChainBoundary
+
+/// A modifier marking the point where an operation's own modifiers begin, and the modifiers
+/// applied to it by the ``OperationTransform``s in scope end.
+struct _OperationChainBoundary<Operation: OperationRequest>: OperationModifier, Sendable {
+  func setup(context: inout OperationContext, using operation: Operation) {
+    // NB: An `OperationRunner` sets its operation up a single time, so setting it up again on
+    // every run would mint a second deduplication storage, re-append its operation controllers,
+    // and re-add its stale-when-revalidate predicates. Descending would also overwrite the
+    // configuration that the transforms in scope just wrote on the way back down the chain.
+    guard context.modifierSetupScope != .operationRun else { return }
+    operation.setup(context: &context)
+  }
+
+  func run(
+    isolation: isolated (any Actor)?,
+    in context: OperationContext,
+    using operation: Operation,
+    with continuation: OperationContinuation<Operation.Value, Operation.Failure>
+  ) async throws(Operation.Failure) -> Operation.Value {
+    try await operation.run(isolation: isolation, in: context, with: continuation)
   }
 }
 

--- a/Tests/OperationTests/OperationTransformTests.swift
+++ b/Tests/OperationTests/OperationTransformTests.swift
@@ -8,7 +8,7 @@ struct OperationTransformTests {
   func doesNotApplyATransformWhenNoneIsInScope() async {
     let counter = RunCounter()
     await #expect(throws: SomeError.self) {
-      try await #run(FailingOperation(counter: counter))
+      try await #run($transformFailingOperation(counter: counter))
     }
     expectNoDifference(counter.count, 1)
   }
@@ -18,7 +18,7 @@ struct OperationTransformTests {
     let counter = RunCounter()
     await withOperationTransform(RetryingTransform(limit: 3)) {
       await #expect(throws: SomeError.self) {
-        try await #run(FailingOperation(counter: counter))
+        try await #run($transformFailingOperation(counter: counter))
       }
     }
     expectNoDifference(counter.count, 4)
@@ -29,7 +29,7 @@ struct OperationTransformTests {
     let counter = RunCounter()
     await withOperationTransform(RetryingTransform(limit: 3)) {}
     await #expect(throws: SomeError.self) {
-      try await #run(FailingOperation(counter: counter))
+      try await #run($transformFailingOperation(counter: counter))
     }
     expectNoDifference(counter.count, 1)
   }
@@ -37,8 +37,8 @@ struct OperationTransformTests {
   @Test("Applies The Transform To Operations Of Differing Value And Failure Types")
   func appliesTheTransformToOperationsOfDifferingValueAndFailureTypes() async {
     await withOperationTransform(RetryingTransform(limit: 1)) {
-      let number = await #run(ConstantOperation(value: 1))
-      let text = await #run(ConstantOperation(value: "blob"))
+      let number = await #run($transformConstantNumber)
+      let text = await #run($transformConstantText)
       expectNoDifference(number, 1)
       expectNoDifference(text, "blob")
     }
@@ -49,7 +49,7 @@ struct OperationTransformTests {
     // `retry(limit:)` writes its limit into the context during setup, so the operation can only
     // read back 4 if the transform's modifiers were set up.
     let limit = await withOperationTransform(RetryingTransform(limit: 4)) {
-      await #run(MaxRetriesOperation())
+      await #run($transformMaxRetries)
     }
     expectNoDifference(limit, 4)
   }
@@ -60,7 +60,7 @@ struct OperationTransformTests {
     await withOperationTransform(RetryingTransform(limit: 10)) {
       await #expect(throws: SomeError.self) {
         try await #run(
-          FailingOperation(counter: counter)
+          $transformFailingOperation(counter: counter)
             .retry(limit: 1)
             .backoff(.noBackoff)
             .delayer(.noDelay)
@@ -70,6 +70,18 @@ struct OperationTransformTests {
     expectNoDifference(counter.count, 11)
   }
 
+  @Test("Reports The Setup Scope Of The Run To The Operation")
+  func reportsTheSetupScopeOfTheRunToTheOperation() async {
+    // The scope stays set for the duration of the run, so an operation can tell whether any
+    // transforms were in scope for it.
+    let outside = await #run($transformSetupScope)
+    let inside = await withOperationTransform(NoOpTransform()) {
+      await #run($transformSetupScope)
+    }
+    expectNoDifference(outside, .runtimeInitialSetup)
+    expectNoDifference(inside, .operationRun)
+  }
+
   // MARK: - Operation Stores
 
   @Test("Applies A Transform's Retry Limit To A Store Created By An Operation Client")
@@ -77,7 +89,7 @@ struct OperationTransformTests {
     // The client applies its own `retry(limit:)` to every operation it creates a store for, which
     // sits closer to the operation than the transform's does.
     let counter = RunCounter()
-    let store = OperationClient().store(for: FailingQuery(counter: counter))
+    let store = OperationClient().store(for: $transformFailingQuery(counter: counter))
     await withOperationTransform(RetryingTransform(limit: 10)) {
       _ = try? await store.fetch()
     }
@@ -86,7 +98,7 @@ struct OperationTransformTests {
 
   @Test("Applies A Transform's Backoff Function To A Store Created By An Operation Client")
   func appliesATransformsBackoffFunctionToAStoreCreatedByAnOperationClient() async throws {
-    let store = OperationClient().store(for: BackoffReportingQuery())
+    let store = OperationClient().store(for: $transformBackoffQuery)
     let backoff = try await withOperationTransform(ConstantBackoffTransform(seconds: 99)) {
       try await store.fetch()
     }
@@ -98,7 +110,7 @@ struct OperationTransformTests {
     // A store's modifiers are only ever set up once. Setting them up again on each run would mint
     // a second deduplication storage, leaving concurrent runs unable to see each other.
     let counter = RunCounter()
-    let store = OperationClient().store(for: SlowQuery(counter: counter))
+    let store = OperationClient().store(for: $transformSlowQuery(counter: counter))
     await withOperationTransform(NoOpTransform()) {
       async let first: Void = { _ = try? await store.fetch() }()
       async let second: Void = { _ = try? await store.fetch() }()
@@ -112,7 +124,7 @@ struct OperationTransformTests {
     // The transform steers the store's retryer rather than taking the loop, so the loop stays
     // inside `deduplicated()` and both callers share a single run's worth of attempts.
     let counter = RunCounter()
-    let store = OperationClient().store(for: SlowFailingQuery(counter: counter))
+    let store = OperationClient().store(for: $transformSlowFailingQuery(counter: counter))
     await withOperationTransform(RetryingTransform(limit: 2)) {
       async let first: Void = { _ = try? await store.fetch() }()
       async let second: Void = { _ = try? await store.fetch() }()
@@ -124,7 +136,7 @@ struct OperationTransformTests {
   @Test("Does Not Duplicate Operation Controllers When A Transform Is In Scope")
   func doesNotDuplicateOperationControllersWhenATransformIsInScope() async throws {
     let store = OperationClient()
-      .store(for: ControllerCountingQuery().controlled(by: NoOpController()))
+      .store(for: $transformControllerQuery.controlled(by: NoOpController()))
     let outside = try await store.fetch()
     let inside = try await withOperationTransform(NoOpTransform()) { try await store.fetch() }
     expectNoDifference(inside, outside)
@@ -135,7 +147,7 @@ struct OperationTransformTests {
     let recorder = TagRecorder()
     await withOperationTransform(TaggingTransform(tag: "outer", recorder: recorder)) {
       await withOperationTransform(TaggingTransform(tag: "inner", recorder: recorder)) {
-        _ = await #run(ConstantOperation(value: 1))
+        _ = await #run($transformConstantNumber)
       }
     }
     expectNoDifference(recorder.tags, ["outer", "inner"])
@@ -148,7 +160,7 @@ struct OperationTransformTests {
       TaggingTransform(tag: "first", recorder: recorder),
       TaggingTransform(tag: "second", recorder: recorder)
     ]) {
-      _ = await #run(ConstantOperation(value: 1))
+      _ = await #run($transformConstantNumber)
     }
     // Modifiers run outermost first, so the last transform given is the one nearest the operation.
     expectNoDifference(recorder.tags, ["first", "second"])
@@ -172,7 +184,7 @@ struct OperationTransformTests {
     let recorder = TagRecorder()
     await withOperationTransform(TaggingTransform(tag: "outer", recorder: recorder)) {
       await withOperationTransforms([TaggingTransform(tag: "only", recorder: recorder)]) {
-        _ = await #run(ConstantOperation(value: 1))
+        _ = await #run($transformConstantNumber)
       }
     }
     expectNoDifference(recorder.tags, ["only"])
@@ -186,7 +198,7 @@ struct OperationTransformTests {
         TaggingTransform(tag: "only", recorder: recorder),
         behavior: .override
       ) {
-        _ = await #run(ConstantOperation(value: 1))
+        _ = await #run($transformConstantNumber)
       }
     }
     expectNoDifference(recorder.tags, ["only"])
@@ -203,7 +215,7 @@ struct OperationTransformTests {
         ],
         behavior: .append
       ) {
-        _ = await #run(ConstantOperation(value: 1))
+        _ = await #run($transformConstantNumber)
       }
     }
     expectNoDifference(recorder.tags, ["outer", "first", "second"])
@@ -213,11 +225,11 @@ struct OperationTransformTests {
   func handsASingleTransformTheOperationsOwnType() async {
     let recorder = TagRecorder()
     await withOperationTransform(OperandNamingTransform(recorder: recorder)) {
-      _ = await #run(ConstantOperation(value: 1))
+      _ = await #run($transformConstantNumber)
     }
     expectNoDifference(recorder.tags.count, 1)
     expectNoDifference(recorder.tags[0].contains("AnyOperation"), false)
-    expectNoDifference(recorder.tags[0].contains("ConstantOperation"), true)
+    expectNoDifference(recorder.tags[0].contains("transformConstantNumber"), true)
   }
 
   @Test("Hands The Innermost Of Several Transforms The Operation's Own Type")
@@ -228,10 +240,10 @@ struct OperationTransformTests {
       OperandNamingTransform(recorder: recorder)
     ]
     await withOperationTransforms(transforms) {
-      _ = await #run(ConstantOperation(value: 1))
+      _ = await #run($transformConstantNumber)
     }
     expectNoDifference(recorder.tags.last?.contains("AnyOperation"), false)
-    expectNoDifference(recorder.tags.last?.contains("ConstantOperation"), true)
+    expectNoDifference(recorder.tags.last?.contains("transformConstantNumber"), true)
   }
 
   @Test("Applies Nothing When Given An Empty Sequence")
@@ -240,7 +252,7 @@ struct OperationTransformTests {
     await withOperationTransform(RetryingTransform(limit: 3)) {
       _ = await withOperationTransforms([]) {
         await #expect(throws: SomeError.self) {
-          try await #run(FailingOperation(counter: counter))
+          try await #run($transformFailingOperation(counter: counter))
         }
       }
     }
@@ -255,7 +267,7 @@ struct OperationTransformTests {
     }
     await Task.detached {
       await withOperationTransforms(carried) {
-        _ = try? await #run(FailingOperation(counter: counter))
+        _ = try? await #run($transformFailingOperation(counter: counter))
       }
     }
     .value
@@ -268,7 +280,7 @@ struct OperationTransformTests {
     await withOperationTransform(RetryingTransform(limit: 3)) {
       await withTaskGroup(of: Void.self) { group in
         group.addTask {
-          _ = try? await #run(FailingOperation(counter: counter))
+          _ = try? await #run($transformFailingOperation(counter: counter))
         }
         await group.waitForAll()
       }
@@ -281,7 +293,7 @@ struct OperationTransformTests {
     let yielded = RecursiveLock([Int]())
     let value = await withOperationTransform(RetryingTransform(limit: 1)) {
       await #run(
-        YieldingOperation(),
+        $transformYieldingOperation,
         context: OperationContext(),
         continuation: OperationContinuation { result, _ in
           guard case .success(let next) = result else { return }
@@ -314,79 +326,8 @@ private struct ConstantBackoffTransform: OperationTransform {
   }
 }
 
-private struct FailingQuery: QueryRequest, Sendable {
-  let counter: RunCounter
-
-  var path: OperationPath { OperationPath("transform-tests-failing-query") }
-
-  func fetch(
-    isolation: isolated (any Actor)?,
-    in context: OperationContext,
-    with continuation: OperationContinuation<Int, any Error>
-  ) async throws -> Int {
-    self.counter.increment()
-    throw SomeError()
-  }
-}
-
-private struct SlowQuery: QueryRequest, Sendable {
-  let counter: RunCounter
-
-  var path: OperationPath { OperationPath("transform-tests-slow-query") }
-
-  func fetch(
-    isolation: isolated (any Actor)?,
-    in context: OperationContext,
-    with continuation: OperationContinuation<Int, any Error>
-  ) async throws -> Int {
-    self.counter.increment()
-    try await Task.sleep(for: .milliseconds(100))
-    return 1
-  }
-}
-
-private struct SlowFailingQuery: QueryRequest, Sendable {
-  let counter: RunCounter
-
-  var path: OperationPath { OperationPath("transform-tests-slow-failing-query") }
-
-  func fetch(
-    isolation: isolated (any Actor)?,
-    in context: OperationContext,
-    with continuation: OperationContinuation<Int, any Error>
-  ) async throws -> Int {
-    self.counter.increment()
-    try await Task.sleep(for: .milliseconds(50))
-    throw SomeError()
-  }
-}
-
-private struct BackoffReportingQuery: QueryRequest, Sendable {
-  var path: OperationPath { OperationPath("transform-tests-backoff-query") }
-
-  func fetch(
-    isolation: isolated (any Actor)?,
-    in context: OperationContext,
-    with continuation: OperationContinuation<OperationDuration, any Error>
-  ) async throws -> OperationDuration {
-    context.operationBackoffFunction(1)
-  }
-}
-
-private struct ControllerCountingQuery: QueryRequest, Sendable {
-  var path: OperationPath { OperationPath("transform-tests-controller-query") }
-
-  func fetch(
-    isolation: isolated (any Actor)?,
-    in context: OperationContext,
-    with continuation: OperationContinuation<Int, any Error>
-  ) async throws -> Int {
-    context.operationControllers.count
-  }
-}
-
 private struct NoOpController: OperationController {
-  typealias State = QueryState<Int, any Error>
+  typealias State = QueryState<Int, Never>
 
   func control(with controls: OperationControls<State>) -> OperationSubscription { .empty }
 }
@@ -467,7 +408,7 @@ private final class TagRecorder: Sendable {
   }
 }
 
-private final class RunCounter: Sendable {
+private final class RunCounter: Hashable, Sendable {
   private let _count = RecursiveLock(0)
 
   var count: Int {
@@ -477,50 +418,80 @@ private final class RunCounter: Sendable {
   func increment() {
     self._count.withLock { $0 += 1 }
   }
-}
 
-private struct FailingOperation: OperationRequest, Sendable {
-  let counter: RunCounter
+  static func == (lhs: RunCounter, rhs: RunCounter) -> Bool {
+    lhs === rhs
+  }
 
-  func run(
-    isolation: isolated (any Actor)?,
-    in context: OperationContext,
-    with continuation: OperationContinuation<Int, any Error>
-  ) async throws -> Int {
-    self.counter.increment()
-    throw SomeError()
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(ObjectIdentifier(self))
   }
 }
 
-private struct ConstantOperation<Value: Sendable>: OperationRequest, Sendable {
-  let value: Value
+// MARK: - Operations
 
-  func run(
-    isolation: isolated (any Actor)?,
-    in context: OperationContext,
-    with continuation: OperationContinuation<Value, Never>
-  ) async throws(Never) -> Value {
-    self.value
-  }
+@OperationRequest
+private func transformFailingOperation(counter: RunCounter) throws -> Int {
+  counter.increment()
+  throw SomeError()
 }
 
-private struct MaxRetriesOperation: OperationRequest, Sendable {
-  func run(
-    isolation: isolated (any Actor)?,
-    in context: OperationContext,
-    with continuation: OperationContinuation<Int, Never>
-  ) async throws(Never) -> Int {
-    context.operationMaxRetries
-  }
+@OperationRequest
+private func transformSetupScope(
+  context: OperationContext
+) -> OperationContext.ModifierSetupScope {
+  context.modifierSetupScope
 }
 
-private struct YieldingOperation: OperationRequest, Sendable {
-  func run(
-    isolation: isolated (any Actor)?,
-    in context: OperationContext,
-    with continuation: OperationContinuation<Int, Never>
-  ) async throws(Never) -> Int {
-    continuation.yield(1)
-    return 2
-  }
+@OperationRequest
+private func transformConstantNumber() -> Int {
+  1
+}
+
+@OperationRequest
+private func transformConstantText() -> String {
+  "blob"
+}
+
+@OperationRequest
+private func transformMaxRetries(context: OperationContext) -> Int {
+  context.operationMaxRetries
+}
+
+@OperationRequest
+private func transformYieldingOperation(continuation: OperationContinuation<Int, Never>) -> Int {
+  continuation.yield(1)
+  return 2
+}
+
+// MARK: - Queries
+
+@QueryRequest
+private func transformFailingQuery(counter: RunCounter) throws -> Int {
+  counter.increment()
+  throw SomeError()
+}
+
+@QueryRequest
+private func transformSlowQuery(counter: RunCounter) async throws -> Int {
+  counter.increment()
+  try await Task.sleep(for: .milliseconds(100))
+  return 1
+}
+
+@QueryRequest
+private func transformSlowFailingQuery(counter: RunCounter) async throws -> Int {
+  counter.increment()
+  try await Task.sleep(for: .milliseconds(50))
+  throw SomeError()
+}
+
+@QueryRequest
+private func transformBackoffQuery(context: OperationContext) -> OperationDuration {
+  context.operationBackoffFunction(1)
+}
+
+@QueryRequest
+private func transformControllerQuery(context: OperationContext) -> Int {
+  context.operationControllers.count
 }

--- a/Tests/OperationTests/OperationTransformTests.swift
+++ b/Tests/OperationTests/OperationTransformTests.swift
@@ -54,8 +54,8 @@ struct OperationTransformTests {
     expectNoDifference(limit, 4)
   }
 
-  @Test("An Operation's Own Retry Limit Takes Precedence Over The Transform's")
-  func anOperationsOwnRetryLimitTakesPrecedenceOverTheTransforms() async {
+  @Test("A Transform's Retry Limit Takes Precedence Over The Operation's Own")
+  func aTransformsRetryLimitTakesPrecedenceOverTheOperationsOwn() async {
     let counter = RunCounter()
     await withOperationTransform(RetryingTransform(limit: 10)) {
       await #expect(throws: SomeError.self) {
@@ -67,7 +67,67 @@ struct OperationTransformTests {
         )
       }
     }
-    expectNoDifference(counter.count, 2)
+    expectNoDifference(counter.count, 11)
+  }
+
+  // MARK: - Operation Stores
+
+  @Test("Applies A Transform's Retry Limit To A Store Created By An Operation Client")
+  func appliesATransformsRetryLimitToAStoreCreatedByAnOperationClient() async {
+    // The client applies its own `retry(limit:)` to every operation it creates a store for, which
+    // sits closer to the operation than the transform's does.
+    let counter = RunCounter()
+    let store = OperationClient().store(for: FailingQuery(counter: counter))
+    await withOperationTransform(RetryingTransform(limit: 10)) {
+      _ = try? await store.fetch()
+    }
+    expectNoDifference(counter.count, 11)
+  }
+
+  @Test("Applies A Transform's Backoff Function To A Store Created By An Operation Client")
+  func appliesATransformsBackoffFunctionToAStoreCreatedByAnOperationClient() async throws {
+    let store = OperationClient().store(for: BackoffReportingQuery())
+    let backoff = try await withOperationTransform(ConstantBackoffTransform(seconds: 99)) {
+      try await store.fetch()
+    }
+    expectNoDifference(backoff, .seconds(99))
+  }
+
+  @Test("Does Not Break Deduplication When A Transform Is In Scope")
+  func doesNotBreakDeduplicationWhenATransformIsInScope() async {
+    // A store's modifiers are only ever set up once. Setting them up again on each run would mint
+    // a second deduplication storage, leaving concurrent runs unable to see each other.
+    let counter = RunCounter()
+    let store = OperationClient().store(for: SlowQuery(counter: counter))
+    await withOperationTransform(NoOpTransform()) {
+      async let first: Void = { _ = try? await store.fetch() }()
+      async let second: Void = { _ = try? await store.fetch() }()
+      _ = await (first, second)
+    }
+    expectNoDifference(counter.count, 1)
+  }
+
+  @Test("Retries Within Deduplication When A Transform Raises The Retry Limit")
+  func retriesWithinDeduplicationWhenATransformRaisesTheRetryLimit() async {
+    // The transform steers the store's retryer rather than taking the loop, so the loop stays
+    // inside `deduplicated()` and both callers share a single run's worth of attempts.
+    let counter = RunCounter()
+    let store = OperationClient().store(for: SlowFailingQuery(counter: counter))
+    await withOperationTransform(RetryingTransform(limit: 2)) {
+      async let first: Void = { _ = try? await store.fetch() }()
+      async let second: Void = { _ = try? await store.fetch() }()
+      _ = await (first, second)
+    }
+    expectNoDifference(counter.count, 3)
+  }
+
+  @Test("Does Not Duplicate Operation Controllers When A Transform Is In Scope")
+  func doesNotDuplicateOperationControllersWhenATransformIsInScope() async throws {
+    let store = OperationClient()
+      .store(for: ControllerCountingQuery().controlled(by: NoOpController()))
+    let outside = try await store.fetch()
+    let inside = try await withOperationTransform(NoOpTransform()) { try await store.fetch() }
+    expectNoDifference(inside, outside)
   }
 
   @Test("A Nested Transform Composes With The One Around It")
@@ -235,6 +295,101 @@ struct OperationTransformTests {
 }
 
 // MARK: - Helpers
+
+private struct NoOpTransform: OperationTransform {
+  func apply<Operation: OperationRequest>(
+    to operation: Operation
+  ) -> any OperationRequest<Operation.Value, Operation.Failure> {
+    operation
+  }
+}
+
+private struct ConstantBackoffTransform: OperationTransform {
+  let seconds: Int
+
+  func apply<Operation: OperationRequest>(
+    to operation: Operation
+  ) -> any OperationRequest<Operation.Value, Operation.Failure> {
+    operation.backoff(.constant(.seconds(self.seconds)))
+  }
+}
+
+private struct FailingQuery: QueryRequest, Sendable {
+  let counter: RunCounter
+
+  var path: OperationPath { OperationPath("transform-tests-failing-query") }
+
+  func fetch(
+    isolation: isolated (any Actor)?,
+    in context: OperationContext,
+    with continuation: OperationContinuation<Int, any Error>
+  ) async throws -> Int {
+    self.counter.increment()
+    throw SomeError()
+  }
+}
+
+private struct SlowQuery: QueryRequest, Sendable {
+  let counter: RunCounter
+
+  var path: OperationPath { OperationPath("transform-tests-slow-query") }
+
+  func fetch(
+    isolation: isolated (any Actor)?,
+    in context: OperationContext,
+    with continuation: OperationContinuation<Int, any Error>
+  ) async throws -> Int {
+    self.counter.increment()
+    try await Task.sleep(for: .milliseconds(100))
+    return 1
+  }
+}
+
+private struct SlowFailingQuery: QueryRequest, Sendable {
+  let counter: RunCounter
+
+  var path: OperationPath { OperationPath("transform-tests-slow-failing-query") }
+
+  func fetch(
+    isolation: isolated (any Actor)?,
+    in context: OperationContext,
+    with continuation: OperationContinuation<Int, any Error>
+  ) async throws -> Int {
+    self.counter.increment()
+    try await Task.sleep(for: .milliseconds(50))
+    throw SomeError()
+  }
+}
+
+private struct BackoffReportingQuery: QueryRequest, Sendable {
+  var path: OperationPath { OperationPath("transform-tests-backoff-query") }
+
+  func fetch(
+    isolation: isolated (any Actor)?,
+    in context: OperationContext,
+    with continuation: OperationContinuation<OperationDuration, any Error>
+  ) async throws -> OperationDuration {
+    context.operationBackoffFunction(1)
+  }
+}
+
+private struct ControllerCountingQuery: QueryRequest, Sendable {
+  var path: OperationPath { OperationPath("transform-tests-controller-query") }
+
+  func fetch(
+    isolation: isolated (any Actor)?,
+    in context: OperationContext,
+    with continuation: OperationContinuation<Int, any Error>
+  ) async throws -> Int {
+    context.operationControllers.count
+  }
+}
+
+private struct NoOpController: OperationController {
+  typealias State = QueryState<Int, any Error>
+
+  func control(with controls: OperationControls<State>) -> OperationSubscription { .empty }
+}
 
 private struct SomeError: Equatable, Error {}
 


### PR DESCRIPTION
Currently, `setup` is only called when `OperationRunner` is created. #25 made it also run inside `run`, however this implementation is error-prone because things like controllers get created and then discarded.

Furthermore, applying modifiers like `retry` in `withOperationTransform` had no effect on operations created through the default `OperationClient` since the inner-most retry would win the setup.

This PR adds a new context property such that a modifier can tell when it is being initialized in either `run` or in the `OperationRunner` init, and adjust its behavior accordingly.