### PR TITLE
Allow Explicit Merging of Retry Conditions

### DIFF
--- a/Sources/OperationCore/Documentation.docc/OperationCore.md
+++ b/Sources/OperationCore/Documentation.docc/OperationCore.md
@@ -473,11 +473,12 @@ The library ships with a handful of package traits, which allow you to condition
 - ``ModifiedOperation``
 - ``OperationRequest/backoff(_:)``
 - ``OperationRequest/clock(_:)``
-- ``OperationRequest/retry(limit:)``
-- ``OperationRequest/retry(limit:when:)``
-- ``OperationRequest/retry(when:)``
-- ``OperationRequest/retry(_:)``
+- ``OperationRequest/retry(limit:merging:)``
+- ``OperationRequest/retry(limit:merging:when:)``
+- ``OperationRequest/retry(merging:when:)``
+- ``OperationRequest/retry(_:merging:)``
 - ``OperationRetryCondition``
+- ``OperationRetryCondition/Merge``
 - ``OperationRequest/taskConfiguration(_:)-((OperationTaskConfiguration)->Void)``
 - ``OperationRequest/deduplicated()``
 - ``OperationRequest/modifier(_:)``

--- a/Sources/OperationCore/ModifierSetupScope.swift
+++ b/Sources/OperationCore/ModifierSetupScope.swift
@@ -31,7 +31,8 @@ extension OperationContext {
     ///
     /// Modifiers write their configuration before setting up the operation they're attached to,
     /// so the ones applied closest to the operation win. This is why an operation's own
-    /// ``OperationRequest/retry(limit:)`` beats the one `OperationClient` applies by default.
+    /// ``OperationRequest/retry(limit:merging:)`` beats the one `OperationClient` applies by
+    /// default.
     case runtimeInitialSetup
 
     /// The setup of the modifiers that the ``OperationTransform``s in scope apply to a single run.

--- a/Sources/OperationCore/Modifiers/OperationModifier.swift
+++ b/Sources/OperationCore/Modifiers/OperationModifier.swift
@@ -3,8 +3,8 @@
 /// A protocol for defining reusable and composable logic for operations.
 ///
 /// The library comes with many built-in modifiers that you can use to customize the logic and
-/// behavior of an operation. For instance, ``OperationRequest/retry(limit:)`` adds retry logic
-/// with backoff to any operation regardless of whether or not its a ``QueryRequest``,
+/// behavior of an operation. For instance, ``OperationRequest/retry(limit:merging:)`` adds retry
+/// logic with backoff to any operation regardless of whether or not its a ``QueryRequest``,
 /// ``MutationRequest``, or ``PaginatedRequest``.
 ///
 /// To create your own modifier, create a data type that conforms to this protocol. We'll create a

--- a/Sources/OperationCore/Modifiers/RetryOperation.swift
+++ b/Sources/OperationCore/Modifiers/RetryOperation.swift
@@ -19,7 +19,7 @@
 ///   && OperationRetryCondition { error, _ in !(error is AuthenticationError) }
 /// ```
 public struct OperationRetryCondition: Sendable {
-  fileprivate typealias Predicate = @Sendable (any Error, OperationContext) async -> Bool
+  private typealias Predicate = @Sendable (any Error, OperationContext) async -> Bool
 
   /// The upper bound this condition places on the number of retries, if it places one.
   ///
@@ -395,18 +395,14 @@ public struct _RetryModifier<Operation: OperationRequest>: OperationModifier, Se
       self.condition,
       with: context.operationRetryCondition
     )
-
-    // NB: The innermost retry modifier runs the loop. Within a setup pass, that's the last one
-    // set up. A transform's modifiers are always outside the operation's own, which were set up in
-    // an earlier pass, so a claim from an earlier pass is never taken over.
-    let claim = context[RetryerClaimKey.self]
-    if claim == nil || claim?.scope == context.modifierSetupScope {
-      context[RetryerClaimKey.self] = RetryerClaim(
-        id: self.retryerId,
-        scope: context.modifierSetupScope
-      )
-    }
     operation.setup(context: &context)
+
+    // NB: Setup unwinds from the innermost modifier outwards, so the innermost retry modifier
+    // claims the loop first. A transform's modifiers are outside the operation's own, so they never
+    // take over its claim.
+    if context[RetryerIDKey.self] == nil {
+      context[RetryerIDKey.self] = self.retryerId
+    }
   }
 
   public func run(
@@ -415,11 +411,14 @@ public struct _RetryModifier<Operation: OperationRequest>: OperationModifier, Se
     using operation: Operation,
     with continuation: OperationContinuation<Operation.Value, Operation.Failure>
   ) async throws(Operation.Failure) -> Operation.Value {
-    guard context[RetryerClaimKey.self]?.id === self.retryerId else {
+    guard context[RetryerIDKey.self] === self.retryerId else {
       return try await operation.run(isolation: isolation, in: context, with: continuation)
     }
 
     var context = context
+    // NB: Nothing inside this modifier runs a retry loop, and clearing the claim keeps it from
+    // stopping an operation run with this context from claiming its own.
+    context[RetryerIDKey.self] = nil
     var retryIndex: Int?
     while true {
       context.operationRetryIndex = retryIndex
@@ -442,17 +441,12 @@ public struct _RetryModifier<Operation: OperationRequest>: OperationModifier, Se
   }
 }
 
-// MARK: - RetryerClaim
+// MARK: - RetryerID
 
 private final class RetryerID: Sendable {}
 
-private struct RetryerClaim: Sendable {
-  let id: RetryerID
-  let scope: OperationContext.ModifierSetupScope
-}
-
-private enum RetryerClaimKey: OperationContext.Key {
-  static var defaultValue: RetryerClaim? { nil }
+private enum RetryerIDKey: OperationContext.Key {
+  static var defaultValue: RetryerID? { nil }
 }
 
 // MARK: - OperationContext

--- a/Sources/OperationCore/Modifiers/RetryOperation.swift
+++ b/Sources/OperationCore/Modifiers/RetryOperation.swift
@@ -3,8 +3,9 @@
 /// A condition that determines whether or not an operation is retried after it throws an error.
 ///
 /// A retry condition pairs an optional upper bound on the number of retries, which is published to
-/// ``OperationContext/operationMaxRetries``, with a predicate that inspects the thrown error. Both
-/// must permit a retry in order for one to occur.
+/// ``OperationContext/operationMaxRetries``, with an optional predicate that inspects the thrown
+/// error. A retry occurs when the bound has not been reached, and the predicate permits one. A
+/// condition without a predicate, such as ``maxRetries(_:)``, only places a bound.
 ///
 /// The bound is kept separate from the predicate rather than being folded into it because it must
 /// be known _before_ an attempt runs in order to power ``OperationContext/isKnownLastRunAttempt``.
@@ -18,13 +19,15 @@
 ///   && OperationRetryCondition { error, _ in !(error is AuthenticationError) }
 /// ```
 public struct OperationRetryCondition: Sendable {
+  fileprivate typealias Predicate = @Sendable (any Error, OperationContext) async -> Bool
+
   /// The upper bound this condition places on the number of retries, if it places one.
   ///
   /// A nil value indicates that this condition is unbounded, and permits retries for as long as its
   /// predicate does.
   public var maxRetries: Int?
 
-  private let predicate: @Sendable (any Error, OperationContext) async -> Bool
+  private let predicate: Predicate?
 
   /// Creates a bounded retry condition from a predicate you specify.
   ///
@@ -35,6 +38,10 @@ public struct OperationRetryCondition: Sendable {
     maxRetries: Int? = nil,
     _ predicate: @escaping @Sendable (any Error, OperationContext) async -> Bool
   ) {
+    self.init(maxRetries: maxRetries, predicate: predicate)
+  }
+
+  private init(maxRetries: Int?, predicate: Predicate?) {
     self.maxRetries = maxRetries
     self.predicate = predicate
   }
@@ -42,8 +49,8 @@ public struct OperationRetryCondition: Sendable {
   /// Evaluates this condition with the specified `error` and `context`.
   ///
   /// A retry is permitted only when the retries performed so far are within ``maxRetries``, and
-  /// this condition's predicate permits one. The predicate is not evaluated when the bound has
-  /// already been reached.
+  /// this condition's predicate, if it has one, permits one. The predicate is not evaluated when
+  /// the bound has already been reached.
   ///
   /// - Parameters:
   ///   - error: The error thrown by an operation attempt.
@@ -51,7 +58,7 @@ public struct OperationRetryCondition: Sendable {
   /// - Returns: Whether or not to perform another retry.
   public func evaluate(error: some Error, in context: OperationContext) async -> Bool {
     guard context.performedRetries < self.maxRetries ?? .max else { return false }
-    return await self.predicate(error, context)
+    return await self.predicate?(error, context) ?? true
   }
 }
 
@@ -60,14 +67,19 @@ public struct OperationRetryCondition: Sendable {
 extension OperationRetryCondition {
   /// A condition that permits at most `limit` retries, regardless of the error thrown.
   ///
+  /// This condition has no predicate, so combining it with another condition only affects the
+  /// bound of the result.
+  ///
   /// - Parameter limit: The maximum number of retries.
   /// - Returns: A retry condition.
   public static func maxRetries(_ limit: Int) -> Self {
-    Self(maxRetries: limit) { _, _ in true }
+    Self(maxRetries: limit, predicate: nil)
   }
 
   /// A condition that never permits a retry.
-  public static let never = Self(maxRetries: 0) { _, _ in false }
+  ///
+  /// Like ``maxRetries(_:)``, this condition has no predicate, and only places a bound of 0.
+  public static let never = Self.maxRetries(0)
 }
 
 // MARK: - Combining
@@ -77,19 +89,17 @@ extension OperationRetryCondition {
   ///
   /// The resulting condition is bounded by the smaller of the 2 bounds, and its predicate is the
   /// boolean AND of both predicates. `rhs`'s predicate is not evaluated when `lhs`'s predicate
-  /// returns false.
+  /// returns false. An operand without a predicate leaves the other operand's predicate as is.
   ///
   /// - Parameters:
   ///   - lhs: A retry condition.
   ///   - rhs: A retry condition.
   /// - Returns: A retry condition permitting a retry only when both `lhs` and `rhs` permit one.
   public static func && (lhs: Self, rhs: Self) -> Self {
-    var condition = Self { error, context in
-      guard await lhs.predicate(error, context) else { return false }
-      return await rhs.predicate(error, context)
-    }
-    condition.maxRetries = lhs.combinedMaxRetries(with: rhs)
-    return condition
+    Self(
+      maxRetries: lhs.combinedMaxRetries(with: rhs),
+      predicate: Self.predicate(lhs.predicate, rhs.predicate, shortCircuitingOn: false)
+    )
   }
 
   /// Combines 2 retry conditions such that either one permitting a retry is enough for one to
@@ -97,31 +107,37 @@ extension OperationRetryCondition {
   ///
   /// The resulting condition is bounded by the larger of the 2 bounds, and is unbounded if either
   /// operand is unbounded. `rhs`'s predicate is not evaluated when `lhs`'s predicate returns true.
-  ///
-  /// > Note: Since ``maxRetries(_:)`` carries a predicate that always permits a retry, using it as
-  /// > an operand here makes the combined predicate always permit one too. Impose bounds with
-  /// > ``&&(_:_:)`` on the outside instead.
+  /// An operand without a predicate leaves the other operand's predicate as is.
   ///
   /// - Parameters:
   ///   - lhs: A retry condition.
   ///   - rhs: A retry condition.
   /// - Returns: A retry condition permitting a retry when either `lhs` or `rhs` permits one.
   public static func || (lhs: Self, rhs: Self) -> Self {
-    var condition = Self { error, context in
-      guard await lhs.predicate(error, context) else {
-        return await rhs.predicate(error, context)
-      }
-      return true
+    Self(
+      maxRetries: lhs.unionMaxRetries(with: rhs),
+      predicate: Self.predicate(lhs.predicate, rhs.predicate, shortCircuitingOn: true)
+    )
+  }
+
+  private static func predicate(
+    _ lhs: Predicate?,
+    _ rhs: Predicate?,
+    shortCircuitingOn value: Bool
+  ) -> Predicate? {
+    guard let lhs else { return rhs }
+    guard let rhs else { return lhs }
+    return { error, context in
+      guard await lhs(error, context) != value else { return value }
+      return await rhs(error, context)
     }
-    condition.maxRetries = lhs.unionMaxRetries(with: rhs)
-    return condition
   }
 
   private func combinedMaxRetries(with other: Self) -> Int? {
     switch (self.maxRetries, other.maxRetries) {
-    case let (lhs?, rhs?): min(lhs, rhs)
-    case let (lhs?, nil): lhs
-    case let (nil, rhs?): rhs
+    case (let lhs?, let rhs?): min(lhs, rhs)
+    case (let lhs?, nil): lhs
+    case (nil, let rhs?): rhs
     case (nil, nil): nil
     }
   }
@@ -130,6 +146,71 @@ extension OperationRetryCondition {
     guard let lhs = self.maxRetries, let rhs = other.maxRetries else { return nil }
     return max(lhs, rhs)
   }
+}
+
+// MARK: - Merge
+
+extension OperationRetryCondition {
+  /// How a retry modifier merges its condition with the one already in the context.
+  ///
+  /// Every retry modifier merges its condition with
+  /// ``OperationContext/operationRetryCondition`` during setup, regardless of whether it was
+  /// applied when building the operation, or by an ``OperationTransform``. Modifiers are set up
+  /// outermost first, so the condition a modifier merges with is the one established by the
+  /// modifiers applied after it, or by the transforms around it. Before any retry modifier has been
+  /// set up, that condition permits no retries, and has no predicate.
+  ///
+  /// ```swift
+  /// // The client applies `retry(limit: 3)` around every operation it creates a store for. This
+  /// // narrows that condition to authentication-safe errors, rather than replacing it.
+  /// let operation = $myOperation.retry(merging: .and) { error, _ in
+  ///   !(error is AuthenticationError)
+  /// }
+  /// ```
+  public struct Merge: Sendable {
+    private let merge:
+      @Sendable (OperationRetryCondition, OperationRetryCondition) -> OperationRetryCondition
+
+    /// Creates a merge from a closure you specify.
+    ///
+    /// - Parameter merge: A closure that takes the condition of the modifier being set up, and
+    ///   the condition already in the context, and returns the condition to place in the context.
+    public init(
+      _ merge:
+        @escaping @Sendable (
+          _ condition: OperationRetryCondition,
+          _ existing: OperationRetryCondition
+        ) -> OperationRetryCondition
+    ) {
+      self.merge = merge
+    }
+
+    /// Merges a modifier's `condition` with the `existing` condition in the context.
+    ///
+    /// - Parameters:
+    ///   - condition: The condition of the modifier being set up.
+    ///   - existing: The condition already in the context.
+    /// - Returns: The condition to place in the context.
+    public func merge(
+      _ condition: OperationRetryCondition,
+      with existing: OperationRetryCondition
+    ) -> OperationRetryCondition {
+      self.merge(condition, existing)
+    }
+  }
+}
+
+extension OperationRetryCondition.Merge {
+  /// A merge that replaces the existing condition with the modifier's own.
+  public static let override = Self { condition, _ in condition }
+
+  /// A merge that combines the modifier's condition with the existing one using
+  /// ``OperationRetryCondition/||(_:_:)``.
+  public static let or = Self { condition, existing in condition || existing }
+
+  /// A merge that combines the modifier's condition with the existing one using
+  /// ``OperationRetryCondition/&&(_:_:)``.
+  public static let and = Self { condition, existing in condition && existing }
 }
 
 // MARK: - RetryModifier
@@ -152,9 +233,11 @@ extension OperationRequest {
   /// supports cooperative cancellation, and avoid doing any irreversible synchronous work before
   /// reaching a suspension point in this operation.
   ///
-  /// When multiple retry modifiers are applied to an operation, only the first one applied will
-  /// have any effect. This is to allow you to override the default retry behavior applied by the
-  /// default initializer of ``OperationClient``.
+  /// When multiple retry modifiers are applied to an operation, each one merges its condition with
+  /// the one established by the modifiers around it using `merge`. The default merge of
+  /// ``OperationRetryCondition/Merge/override`` means that only the first one
+  /// applied has any effect. This is to allow you to override the default retry behavior applied
+  /// by the default initializer of ``OperationClient``.
   ///
   /// ```swift
   /// // The operation retry limit is 5, and the second retry modifier
@@ -162,11 +245,17 @@ extension OperationRequest {
   /// let operation = $myOperation
   ///   .retry(limit: 5)
   ///   .retry(limit: 3)
+  ///
+  /// // The operation retry limit is 10, as the first retry modifier
+  /// // takes the larger of the 2 limits.
+  /// let widenedOperation = $myOperation
+  ///   .retry(limit: 5, merging: .or)
+  ///   .retry(limit: 10)
   /// ```
   ///
-  /// A retry modifier applied by an ``OperationTransform`` in scope for a run is the exception to
-  /// that rule, which lets you dial an operation's persistence up or down for a particular piece of
-  /// work. The transform states the limit, and its predicate is OR'd with the operation's own.
+  /// A retry modifier applied by an ``OperationTransform`` in scope for a run is merged with the
+  /// operation's own condition in the same manner, which lets you dial an operation's
+  /// persistence up or down for a particular piece of work.
   ///
   /// ```swift
   /// struct BackgroundSyncTransform: OperationTransform {
@@ -190,11 +279,20 @@ extension OperationRequest {
   /// }
   /// ```
   ///
+  /// However many retry modifiers are applied, only the innermost one runs a retry loop, and the
+  /// others steer that loop through ``OperationContext/operationRetryCondition``. An operation's
+  /// own retry modifiers are always inside the ones applied by a transform, so the loop remains
+  /// inside modifiers such as ``OperationRequest/deduplicated()``.
+  ///
   /// - Parameters:
   ///   - limit: The maximum number of retries.
+  ///   - merge: How this modifier's condition is merged with the existing one.
   /// - Returns: A ``ModifiedOperation``.
-  public func retry(limit: Int) -> ModifiedOperation<Self, _RetryModifier<Self>> {
-    self.retry(.maxRetries(limit))
+  public func retry(
+    limit: Int,
+    merging merge: OperationRetryCondition.Merge = .override
+  ) -> ModifiedOperation<Self, _RetryModifier<Self>> {
+    self.retry(.maxRetries(limit), merging: merge)
   }
 
   /// Applies a retrying to this operation that is limited both by a maximum number of retries, and
@@ -205,7 +303,6 @@ extension OperationRequest {
   /// any backoff is applied, so an error that does not warrant a retry fails the operation
   /// immediately rather than after a delay.
   ///
-  ///
   /// ```swift
   /// // Retries up to 3 times, but never burns a retry on an authentication failure.
   /// let operation = $myOperation.retry(limit: 3) { error, _ in
@@ -213,18 +310,20 @@ extension OperationRequest {
   /// }
   /// ```
   ///
-  /// See ``OperationRequest/retry(limit:)`` for details on backoff, cancellation, and the behavior
-  /// of applying multiple retry modifiers to a single operation.
+  /// See ``OperationRequest/retry(limit:merging:)`` for details on backoff, cancellation, and
+  /// the behavior of applying multiple retry modifiers to a single operation.
   ///
   /// - Parameters:
   ///   - limit: The maximum number of retries.
+  ///   - merge: How this modifier's condition is merged with the existing one.
   ///   - predicate: A predicate that decides whether or not the thrown error warrants a retry.
   /// - Returns: A ``ModifiedOperation``.
   public func retry(
     limit: Int,
+    merging merge: OperationRetryCondition.Merge = .override,
     when predicate: @escaping @Sendable (Failure, OperationContext) async -> Bool
   ) -> ModifiedOperation<Self, _RetryModifier<Self>> {
-    self.retry(.maxRetries(limit) && self.retryCondition(from: predicate))
+    self.retry(.maxRetries(limit) && self.retryCondition(from: predicate), merging: merge)
   }
 
   /// Applies an unbounded retrying to this operation that is limited only by a predicate on the
@@ -236,33 +335,39 @@ extension OperationRequest {
   ///
   /// > Important: This modifier places no upper bound on the number of retries. An operation that
   /// > repeatedly throws errors for which `predicate` returns true will be retried indefinitely.
-  /// > Use ``OperationRequest/retry(limit:when:)`` if you want to impose a bound. Without one,
-  /// > ``OperationContext/operationMaxRetries`` reads as `Int.max` and
+  /// > Use ``OperationRequest/retry(limit:merging:when:)`` if you want to impose a bound, or
+  /// > merge with ``OperationRetryCondition/Merge/and`` to keep the existing one. Without
+  /// > one, ``OperationContext/operationMaxRetries`` reads as `Int.max` and
   /// > ``OperationContext/isKnownLastRunAttempt`` is always false.
   ///
-  /// See ``OperationRequest/retry(limit:)`` for details on backoff, cancellation, and the behavior
-  /// of applying multiple retry modifiers to a single operation.
+  /// See ``OperationRequest/retry(limit:merging:)`` for details on backoff, cancellation, and
+  /// the behavior of applying multiple retry modifiers to a single operation.
   ///
-  /// - Parameter predicate: A predicate that decides whether or not the thrown error warrants a
-  ///   retry.
+  /// - Parameters:
+  ///   - merge: How this modifier's condition is merged with the existing one.
+  ///   - predicate: A predicate that decides whether or not the thrown error warrants a retry.
   /// - Returns: A ``ModifiedOperation``.
   public func retry(
+    merging merge: OperationRetryCondition.Merge = .override,
     when predicate: @escaping @Sendable (Failure, OperationContext) async -> Bool
   ) -> ModifiedOperation<Self, _RetryModifier<Self>> {
-    self.retry(self.retryCondition(from: predicate))
+    self.retry(self.retryCondition(from: predicate), merging: merge)
   }
 
   /// Applies a retrying to this operation using an ``OperationRetryCondition``.
   ///
-  /// See ``OperationRequest/retry(limit:)`` for details on backoff, cancellation, and the behavior
-  /// of applying multiple retry modifiers to a single operation.
+  /// See ``OperationRequest/retry(limit:merging:)`` for details on backoff, cancellation, and
+  /// the behavior of applying multiple retry modifiers to a single operation.
   ///
-  /// - Parameter condition: The condition under which this operation is retried.
+  /// - Parameters:
+  ///   - condition: The condition under which this operation is retried.
+  ///   - merge: How `condition` is merged with the existing one.
   /// - Returns: A ``ModifiedOperation``.
   public func retry(
-    _ condition: OperationRetryCondition
+    _ condition: OperationRetryCondition,
+    merging merge: OperationRetryCondition.Merge = .override
   ) -> ModifiedOperation<Self, _RetryModifier<Self>> {
-    self.modifier(_RetryModifier(condition: condition))
+    self.modifier(_RetryModifier(condition: condition, merge: merge))
   }
 
   private func retryCondition(
@@ -277,25 +382,29 @@ extension OperationRequest {
 
 public struct _RetryModifier<Operation: OperationRequest>: OperationModifier, Sendable {
   let condition: OperationRetryCondition
+  let merge: OperationRetryCondition.Merge
   private let retryerId = RetryerID()
 
-  init(condition: OperationRetryCondition) {
+  init(condition: OperationRetryCondition, merge: OperationRetryCondition.Merge) {
     self.condition = condition
+    self.merge = merge
   }
 
   public func setup(context: inout OperationContext, using operation: Operation) {
-    switch context.modifierSetupScope {
-    case .runtimeInitialSetup:
-      context.operationRetryCondition = self.condition
-      context[RetryerIDKey.self] = self.retryerId
-    case .operationRun:
-      var condition = self.condition || context.operationRetryCondition
-      condition.maxRetries = self.condition.maxRetries
-      context.operationRetryCondition = condition
+    context.operationRetryCondition = self.merge.merge(
+      self.condition,
+      with: context.operationRetryCondition
+    )
 
-      if context[RetryerIDKey.self] == nil {
-        context[RetryerIDKey.self] = self.retryerId
-      }
+    // NB: The innermost retry modifier runs the loop. Within a setup pass, that's the last one
+    // set up. A transform's modifiers are always outside the operation's own, which were set up in
+    // an earlier pass, so a claim from an earlier pass is never taken over.
+    let claim = context[RetryerClaimKey.self]
+    if claim == nil || claim?.scope == context.modifierSetupScope {
+      context[RetryerClaimKey.self] = RetryerClaim(
+        id: self.retryerId,
+        scope: context.modifierSetupScope
+      )
     }
     operation.setup(context: &context)
   }
@@ -306,7 +415,7 @@ public struct _RetryModifier<Operation: OperationRequest>: OperationModifier, Se
     using operation: Operation,
     with continuation: OperationContinuation<Operation.Value, Operation.Failure>
   ) async throws(Operation.Failure) -> Operation.Value {
-    guard context[RetryerIDKey.self] === self.retryerId else {
+    guard context[RetryerClaimKey.self]?.id === self.retryerId else {
       return try await operation.run(isolation: isolation, in: context, with: continuation)
     }
 
@@ -333,12 +442,17 @@ public struct _RetryModifier<Operation: OperationRequest>: OperationModifier, Se
   }
 }
 
-// MARK: - RetryerID
+// MARK: - RetryerClaim
 
 private final class RetryerID: Sendable {}
 
-private enum RetryerIDKey: OperationContext.Key {
-  static var defaultValue: RetryerID? { nil }
+private struct RetryerClaim: Sendable {
+  let id: RetryerID
+  let scope: OperationContext.ModifierSetupScope
+}
+
+private enum RetryerClaimKey: OperationContext.Key {
+  static var defaultValue: RetryerClaim? { nil }
 }
 
 // MARK: - OperationContext
@@ -346,9 +460,10 @@ private enum RetryerIDKey: OperationContext.Key {
 extension OperationContext {
   /// The current retry attempt for the current operation run.
   ///
-  /// This value starts at 0, but increments every time the ``OperationRequest/retry(limit:)``
-  /// modifier retries an operation run. An index value of nil indicates that the operation run is
-  /// currently on its first attempt, and has not been retried yet.
+  /// This value starts at 0, but increments every time the
+  /// ``OperationRequest/retry(limit:merging:)`` modifier retries an operation run. An index value
+  /// of nil indicates that the operation run is currently on its first attempt, and has not been
+  /// retried yet.
   public var operationRetryIndex: Int? {
     get { self[RetryIndexKey.self] }
     set { self[RetryIndexKey.self] = newValue }
@@ -364,8 +479,9 @@ extension OperationContext {
 
   /// The ``OperationRetryCondition`` for an operation run.
   ///
-  /// The default value of this context property permits no retries. Applying any of the
-  /// `retry` modifiers will set this value to the condition that modifier was built from.
+  /// The default value of this context property permits no retries, and has no predicate. Applying
+  /// any of the `retry` modifiers merges the condition that modifier was built from with this value
+  /// using an ``OperationRetryCondition/Merge``, and sets this value to the result.
   ///
   /// The retry loop reads this property on each attempt, and is always the innermost one in the
   /// operation. A retry modifier applied by an ``OperationTransform`` steers that loop rather than
@@ -376,14 +492,15 @@ extension OperationContext {
   }
 
   private enum RetryConditionKey: Key {
-    static var defaultValue: OperationRetryCondition { .maxRetries(0) }
+    static var defaultValue: OperationRetryCondition { .never }
   }
 
   /// The maximum number of retries for an operation run.
   ///
   /// This value is the upper bound imposed by ``operationRetryCondition``, and defaults to 0. Using
-  /// ``OperationRequest/retry(limit:)`` sets it to the `limit` parameter. A condition need not
-  /// impose a bound at all, such as the one created by ``OperationRequest/retry(when:)``, in which
+  /// ``OperationRequest/retry(limit:merging:)`` sets it to the `limit` parameter. A condition need
+  /// not impose a bound at all, such as the one created by
+  /// ``OperationRequest/retry(merging:when:)``, in which
   /// case this property reads as `Int.max`.
   public var operationMaxRetries: Int {
     get { self.operationRetryCondition.maxRetries ?? .max }

--- a/Tests/OperationTests/ModifiersTests/RetryOperationTests.swift
+++ b/Tests/OperationTests/ModifiersTests/RetryOperationTests.swift
@@ -572,6 +572,41 @@ struct RetryOperationTests {
     let count = await query.fetchCount
     expectNoDifference(count, 4)
   }
+
+  @Test("Retries An Operation Run With The Context Of A Retrying Operation")
+  func retriesAnOperationRunWithTheContextOfARetryingOperation() async {
+    let counter = Counter()
+    await #expect(throws: FailingQuery.SomeError.self) {
+      try await #run(
+        $nestedRetryingOperation(counter: counter)
+          .retry(limit: 1)
+          .backoff(.noBackoff)
+          .delayer(.noDelay)
+      )
+    }
+    let count = await counter.count
+    expectNoDifference(count, 6, "The nested operation should retry twice on each of 2 attempts.")
+  }
+}
+
+@OperationRequest
+private func nestedRetryingOperation(
+  counter: Counter,
+  context: OperationContext
+) async throws -> Int {
+  try await #run(
+    $countingFailingOperation(counter: counter)
+      .retry(limit: 2)
+      .backoff(.noBackoff)
+      .delayer(.noDelay),
+    context: context
+  )
+}
+
+@OperationRequest
+private func countingFailingOperation(counter: Counter) async throws -> Int {
+  await counter.increment()
+  throw FailingQuery.SomeError()
 }
 
 private actor Counter {

--- a/Tests/OperationTests/ModifiersTests/RetryOperationTests.swift
+++ b/Tests/OperationTests/ModifiersTests/RetryOperationTests.swift
@@ -420,8 +420,8 @@ struct RetryOperationTests {
     expectNoDifference(count, 0)
   }
 
-  @Test("Or With A Max Retries Operand Always Permits A Retry")
-  func orWithAMaxRetriesOperandAlwaysPermitsARetry() async {
+  @Test("Or With A Max Retries Operand Keeps The Other Operand's Predicate")
+  func orWithAMaxRetriesOperandKeepsTheOtherOperandsPredicate() async {
     let query = CountingQuery()
     await query.ensureFails()
     let store = OperationStore.detached(
@@ -434,9 +434,27 @@ struct RetryOperationTests {
     let count = await query.fetchCount
     expectNoDifference(
       count,
-      4,
-      "`maxRetries` carries an always-true predicate, so using it as an `||` operand makes the combined predicate always permit a retry, leaving only the outer bound of 3 to stop it."
+      1,
+      "`maxRetries` has no predicate, so using it as an `||` operand only affects the bound."
     )
+  }
+
+  @Test("And With A Max Retries Operand Keeps The Other Operand's Predicate")
+  func andWithAMaxRetriesOperandKeepsTheOtherOperandsPredicate() async {
+    let query = CountingQuery()
+    await query.ensureFails()
+    let store = OperationStore.detached(
+      query: query.backoff(.noBackoff)
+        .delayer(.noDelay)
+        .retry(
+          .maxRetries(5)
+            && OperationRetryCondition { _, context in (context.operationRetryIndex ?? -1) < 1 }
+        ),
+      initialValue: nil
+    )
+    _ = try? await store.fetch()
+    let count = await query.fetchCount
+    expectNoDifference(count, 3)
   }
 
   @Test("Or With Never Falls Back To The Other Operand")
@@ -462,6 +480,97 @@ struct RetryOperationTests {
     expectNoDifference(OperationRetryCondition { _, _ in true }.maxRetries, nil)
     expectNoDifference((OperationRetryCondition.maxRetries(4) && .maxRetries(9)).maxRetries, 4)
     expectNoDifference((OperationRetryCondition.maxRetries(4) || .maxRetries(9)).maxRetries, 9)
+  }
+
+  // MARK: - Merge
+
+  @Test("Overrides The Condition Of The Retry Modifiers Applied Around It By Default")
+  func overridesTheConditionOfTheRetryModifiersAppliedAroundItByDefault() async {
+    let query = CountingQuery()
+    await query.ensureFails()
+    let store = OperationStore.detached(
+      query: query.backoff(.noBackoff)
+        .delayer(.noDelay)
+        .retry(limit: 1)
+        .retry(limit: 3) { _, _ in false },
+      initialValue: nil
+    )
+    expectNoDifference(store.context.operationMaxRetries, 1)
+    _ = try? await store.fetch()
+    let count = await query.fetchCount
+    expectNoDifference(count, 2)
+  }
+
+  @Test("Or Merge Combines With The Condition Of The Retry Modifiers Applied Around It")
+  func orMergeCombinesWithTheConditionOfTheRetryModifiersAppliedAroundIt() async {
+    let query = CountingQuery()
+    await query.ensureFails()
+    let store = OperationStore.detached(
+      query: query.backoff(.noBackoff)
+        .delayer(.noDelay)
+        .retry(limit: 1, merging: .or)
+        .retry(limit: 3),
+      initialValue: nil
+    )
+    expectNoDifference(store.context.operationMaxRetries, 3)
+    _ = try? await store.fetch()
+    let count = await query.fetchCount
+    expectNoDifference(count, 4)
+  }
+
+  @Test("And Merge Narrows The Condition Of The Retry Modifiers Applied Around It")
+  func andMergeNarrowsTheConditionOfTheRetryModifiersAppliedAroundIt() async {
+    let query = CountingQuery()
+    await query.ensureFails()
+    let store = OperationStore.detached(
+      query: query.backoff(.noBackoff)
+        .delayer(.noDelay)
+        .retry(merging: .and) { _, context in (context.operationRetryIndex ?? -1) < 1 }
+        .retry(limit: 5),
+      initialValue: nil
+    )
+    expectNoDifference(store.context.operationMaxRetries, 5)
+    _ = try? await store.fetch()
+    let count = await query.fetchCount
+    expectNoDifference(count, 3)
+  }
+
+  @Test("And Merge Permits No Retries Without A Retry Modifier Applied Around It")
+  func andMergePermitsNoRetriesWithoutARetryModifierAppliedAroundIt() async {
+    let query = CountingQuery()
+    await query.ensureFails()
+    let store = OperationStore.detached(
+      query: query.backoff(.noBackoff)
+        .delayer(.noDelay)
+        .retry(limit: 5, merging: .and),
+      initialValue: nil
+    )
+    expectNoDifference(store.context.operationMaxRetries, 0)
+    _ = try? await store.fetch()
+    let count = await query.fetchCount
+    expectNoDifference(count, 1)
+  }
+
+  @Test("Custom Merge Receives The Modifier's Condition And The Existing One")
+  func customMergeReceivesTheModifiersConditionAndTheExistingOne() async {
+    let merge = OperationRetryCondition.Merge { condition, existing in
+      var merged = condition
+      merged.maxRetries = (condition.maxRetries ?? 0) + (existing.maxRetries ?? 0)
+      return merged
+    }
+    let query = CountingQuery()
+    await query.ensureFails()
+    let store = OperationStore.detached(
+      query: query.backoff(.noBackoff)
+        .delayer(.noDelay)
+        .retry(limit: 1, merging: merge)
+        .retry(limit: 2),
+      initialValue: nil
+    )
+    expectNoDifference(store.context.operationMaxRetries, 3)
+    _ = try? await store.fetch()
+    let count = await query.fetchCount
+    expectNoDifference(count, 4)
   }
 }
 

--- a/Tests/OperationTests/OperationTransformTests.swift
+++ b/Tests/OperationTests/OperationTransformTests.swift
@@ -70,6 +70,70 @@ struct OperationTransformTests {
     expectNoDifference(counter.count, 11)
   }
 
+  @Test("Honors A Transform's Retry Predicate When The Operation Has No Retry Modifier")
+  func honorsATransformsRetryPredicateWhenTheOperationHasNoRetryModifier() async {
+    let counter = RunCounter()
+    let transform = ConditionRetryingTransform(
+      condition: .maxRetries(5) && OperationRetryCondition { _, _ in false }
+    )
+    await withOperationTransform(transform) {
+      await #expect(throws: SomeError.self) {
+        try await #run($transformFailingOperation(counter: counter))
+      }
+    }
+    expectNoDifference(counter.count, 1)
+  }
+
+  @Test("A Transform's Retry Condition Replaces The Operation's Own By Default")
+  func aTransformsRetryConditionReplacesTheOperationsOwnByDefault() async {
+    let counter = RunCounter()
+    await withOperationTransform(RetryingTransform(limit: 2)) {
+      await #expect(throws: SomeError.self) {
+        try await #run(
+          $transformFailingOperation(counter: counter)
+            .retry(limit: 5) { _, _ in false }
+            .backoff(.noBackoff)
+            .delayer(.noDelay)
+        )
+      }
+    }
+    expectNoDifference(counter.count, 3)
+  }
+
+  @Test("A Transform Lowers The Operation's Retry Limit With An And Merge")
+  func aTransformLowersTheOperationsRetryLimitWithAnAndMerge() async {
+    let counter = RunCounter()
+    let transform = ConditionRetryingTransform(condition: .maxRetries(1), merge: .and)
+    await withOperationTransform(transform) {
+      await #expect(throws: SomeError.self) {
+        try await #run(
+          $transformFailingOperation(counter: counter)
+            .retry(limit: 5)
+            .backoff(.noBackoff)
+            .delayer(.noDelay)
+        )
+      }
+    }
+    expectNoDifference(counter.count, 2)
+  }
+
+  @Test("A Transform Raises The Retry Limit And Keeps The Operation's Predicate With An Or Merge")
+  func aTransformRaisesTheRetryLimitAndKeepsTheOperationsPredicateWithAnOrMerge() async {
+    let counter = RunCounter()
+    let transform = ConditionRetryingTransform(condition: .maxRetries(10), merge: .or)
+    await withOperationTransform(transform) {
+      await #expect(throws: SomeError.self) {
+        try await #run(
+          $transformFailingOperation(counter: counter)
+            .retry(limit: 1) { _, context in (context.operationRetryIndex ?? -1) < 3 }
+            .backoff(.noBackoff)
+            .delayer(.noDelay)
+        )
+      }
+    }
+    expectNoDifference(counter.count, 5)
+  }
+
   @Test("Reports The Setup Scope Of The Run To The Operation")
   func reportsTheSetupScopeOfTheRunToTheOperation() async {
     // The scope stays set for the duration of the run, so an operation can tell whether any
@@ -341,6 +405,19 @@ private struct RetryingTransform: OperationTransform {
     to operation: Operation
   ) -> any OperationRequest<Operation.Value, Operation.Failure> {
     operation.retry(limit: self.limit).backoff(.noBackoff).delayer(.noDelay)
+  }
+}
+
+private struct ConditionRetryingTransform: OperationTransform {
+  let condition: OperationRetryCondition
+  var merge = OperationRetryCondition.Merge.override
+
+  func apply<Operation: OperationRequest>(
+    to operation: Operation
+  ) -> any OperationRequest<Operation.Value, Operation.Failure> {
+    operation.retry(self.condition, merging: self.merge)
+      .backoff(.noBackoff)
+      .delayer(.noDelay)
   }
 }
 


### PR DESCRIPTION
The current retry modifier applied different condition merging logic depending on the setup scope. 

This PR makes the merging behavior universal across both scopes, and updates the modifier to allow for custom merging behavior (default is `||`).